### PR TITLE
avoid using Array.apply(new Array(), buf) for compatability

### DIFF
--- a/lib/encoding/bufferwriter.js
+++ b/lib/encoding/bufferwriter.js
@@ -87,8 +87,7 @@ BufferWriter.prototype.writeUInt64BEBN = function(bn) {
 
 BufferWriter.prototype.writeUInt64LEBN = function(bn) {
   var buf = bn.toBuffer({size: 8});
-  var reversebuf = new Buffer(Array.apply(new Array(), buf).reverse());
-  this.write(reversebuf);
+  this.writeReverse(buf);
   return this;
 };
 


### PR DESCRIPTION
was running some unit tests using `phantomjs`, got funky err:
```
TypeError: '*l' is not a valid argument for 'Function.prototype.apply' (evaluating 'new Array()')
```

this seemed like a logical fix