### PR TITLE
update with the new link to the community forum

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The complete docs are hosted here: [bitcore documentation](http://bitcore.io/gui
 - [Read the Developer Guide](http://bitcore.io/guide/)
 - [Read the API Reference](http://bitcore.io/api/)
 
-To get community assistance and ask for help with implementation questions, please use our [community forums](http://bitpaylabs.com/c/bitcore).
+To get community assistance and ask for help with implementation questions, please use our [community forums](https://forum.bitcore.io/).
 
 ## Examples
 
@@ -51,7 +51,7 @@ If you find a security issue, please email security@bitpay.com.
 
 ## Contributing
 
-Please send pull requests for bug fixes, code optimization, and ideas for improvement. For more information on how to contribute, please refer to our [CONTRIBUTING](https://github.com/bitpay/bitcore-lib/blob/master/CONTRIBUTING.md) file. 
+Please send pull requests for bug fixes, code optimization, and ideas for improvement. For more information on how to contribute, please refer to our [CONTRIBUTING](https://github.com/bitpay/bitcore-lib/blob/master/CONTRIBUTING.md) file.
 
 ## Building the Browser Bundle
 


### PR DESCRIPTION

The link to the community forum pointed to the old forum --- my as well
just take people to the new forum instead of having them be confused by
the old forum...

