### PR TITLE
hasLowS validation not using correct constant as it is set in base 10 rather than hex

### DIFF
--- a/lib/crypto/signature.js
+++ b/lib/crypto/signature.js
@@ -275,7 +275,7 @@ Signature.isTxDER = function(buf) {
  */
 Signature.prototype.hasLowS = function() {
   if (this.s.lt(new BN(1)) ||
-    this.s.gt(new BN('7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0'))) {
+    this.s.gt(new BN('7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0', 'hex'))) {
     return false;
   }
   return true;

--- a/test/crypto/signature.js
+++ b/test/crypto/signature.js
@@ -278,18 +278,30 @@ describe('Signature', function() {
   describe('#hasLowS', function() {
     it('should detect high and low S', function() {
       var r = new BN('63173831029936981022572627018246571655303050627048489594159321588908385378810');
-      var s = new BN('4331694221846364448463828256391194279133231453999942381442030409253074198130');
-      var s2 = new BN('7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B2000');
+
       var sig = new Signature({
         r: r,
-        s: s
-      });
+        s: new BN('7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A1', 'hex')
+      });            
+      sig.hasLowS().should.equal(false);
+
       var sig2 = new Signature({
         r: r,
-        s: s2
-      });
+        s: new BN('7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0', 'hex')
+      });      
       sig2.hasLowS().should.equal(true);
-      sig.hasLowS().should.equal(false);
+
+      var sig3 = new Signature({
+        r: r,
+        s: new BN(1)
+      });      
+      sig3.hasLowS().should.equal(true);
+
+      var sig4 = new Signature({        
+        r: r,
+        s: new BN(0)
+      });
+      sig4.hasLowS().should.equal(false);
 
     });
   });


### PR DESCRIPTION
I was running this validation on test net and noticed even new transactions I was creating with the latest bitcoin client weren't validating correctly.

I've made the spec tests the boundaries of the low s/high s as well and cleaned it up a little there. Given BP62 is going more mainstream (more nodes running bitcoin 0.11.1 and 0.10.3) this might start to trip people up.