### PR TITLE
Remove Redeem Script Classification Requirement from Script.isScriptHashIn()

### DIFF
--- a/lib/script/script.js
+++ b/lib/script/script.js
@@ -411,8 +411,7 @@ Script.prototype.isScriptHashIn = function() {
     }
     throw e;
   }
-  var type = redeemScript.classify();
-  return type !== Script.types.UNKNOWN;
+  return true
 };
 
 /**

--- a/lib/script/script.js
+++ b/lib/script/script.js
@@ -393,7 +393,7 @@ Script.prototype.isScriptHashOut = function() {
  * Note that these are frequently indistinguishable from pubkeyhashin
  */
 Script.prototype.isScriptHashIn = function() {
-  if (this.chunks.length <= 1) {
+  if (this.chunks.length <= 1 || this.chunks[0].opcodenum === Opcode.OP_RETURN) {
     return false;
   }
   var redeemChunk = this.chunks[this.chunks.length - 1];

--- a/test/script/script.js
+++ b/test/script/script.js
@@ -10,6 +10,7 @@ var Networks = bitcore.Networks;
 var Opcode = bitcore.Opcode;
 var PublicKey = bitcore.PublicKey;
 var Address = bitcore.Address;
+var errors = bitcore.errors;
 
 describe('Script', function() {
 
@@ -379,6 +380,10 @@ describe('Script', function() {
     });
     it('identifies this other problematic non-p2sh in', function() {
       var s = Script.fromString('73 0x3046022100dc7a0a812de14acc479d98ae209402cc9b5e0692bc74b9fe0a2f083e2f9964b002210087caf04a711bebe5339fd7554c4f7940dc37be216a3ae082424a5e164faf549401');
+      s.isScriptHashIn().should.equal(false);
+    });
+    it('should return false for a script whose redeemscript cannot be deserialized', function() {
+      var s = Script.fromBuffer(new Buffer('00024d33', 'hex'));
       s.isScriptHashIn().should.equal(false);
     });
   });

--- a/test/script/script.js
+++ b/test/script/script.js
@@ -372,8 +372,7 @@ describe('Script', function() {
     it('should identify this problematic non-scripthashin scripts', function() {
       var s = new Script('71 0x3044022017053dad84aa06213749df50a03330cfd24d6' +
         'b8e7ddbb6de66c03697b78a752a022053bc0faca8b4049fb3944a05fcf7c93b2861' +
-        '734d39a89b73108f605f70f5ed3401 33 0x0225386e988b84248dc9c30f784b06e' +
-        '02fdec57bbdbd443768eb5744a75ce44a4c');
+        '734d39a89b73108f605f70f5ed3401');
       var s2 = new Script('OP_RETURN 32 0x19fdb20634911b6459e6086658b3a6ad2dc6576bd6826c73ee86a5f9aec14ed9');
       s.isScriptHashIn().should.equal(false);
       s2.isScriptHashIn().should.equal(false);

--- a/test/script/script.js
+++ b/test/script/script.js
@@ -386,6 +386,14 @@ describe('Script', function() {
       var s = Script.fromBuffer(new Buffer('00024d33', 'hex'));
       s.isScriptHashIn().should.equal(false);
     });
+    it('should propagate errors that are unrelated to script validation', function() {
+      var fails = function() {
+        var s = Script.fromBuffer(new Buffer('00024d33', 'hex'));
+        s.chunks[1] = {buf: 1};
+        return s.isScriptHashIn();
+      };
+      fails.should.throw(TypeError);
+    });
   });
 
   describe('#isScripthashOut', function() {


### PR DESCRIPTION
This change fixes an issue where the `Script` object would return an `unknown` script type when trying to classify a redeem script in `Script.isScriptHashIn()`. Every type of redeem script must be defined in `script.js` in order to be recognized. At current, only `Multisig` and `DataOut` redeem script types are supported. In other words, new script types such as those used in CLTV payment channel transactions are not recognized.

This can cause issues where Script implementations [don't recognize a script](https://github.com/bitpay/bitcore-node/blob/master/lib/services/address/index.js#L550-L558), and, in the case of `bitcore-node`, fail to index the transaction, causing issues like https://github.com/bitpay/insight-api/issues/444 where `insight-api` is unable to find a custom p2sh in its leveldb indexes. This is perhaps an implementation oversight on the part of `bitcore-node` but the fact remains that there are _many_ possible redeem scripts, and we shouldn't have to itemize every type for the Script object to recognize them.

Due to the fact that there is little (if any) cost to incorrectly classifying a redeem script as valid after all other script types have been exhausted, and rather than define every possible redeem script type, we should remove this requirement and instead only verify basic attributes like length, ability to be serialized, etc.