### PR TITLE
Use "rmd160" instead of "ripemd160"

### DIFF
--- a/lib/crypto/hash.js
+++ b/lib/crypto/hash.js
@@ -28,7 +28,7 @@ Hash.sha256sha256 = function(buf) {
 
 Hash.ripemd160 = function(buf) {
   $.checkArgument(BufferUtil.isBuffer(buf));
-  return crypto.createHash('ripemd160').update(buf).digest();
+  return crypto.createHash('rmd160').update(buf).digest();
 };
 
 Hash.sha256ripemd160 = function(buf) {


### PR DESCRIPTION
For browser compatibility. Related: https://github.com/crypto-browserify/crypto-browserify/issues/135