### PR TITLE
create-hash instead crypto.createHash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,8 @@ report
 .DS_Store
 
 
-bitcore.js
-bitcore.min.js
-bitcore.js.sig
-bitcore.min.js.sig
+bitcore-lib.js
+bitcore-lib.min.js
+bitcore-lib.js.sig
+bitcore-lib.min.js.sig
 tests.js

--- a/lib/crypto/hash.js
+++ b/lib/crypto/hash.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var sha512 = require('sha512');
-var crypto = require('crypto');
+var createHash = require('create-hash');
 var BufferUtil = require('../util/buffer');
 var $ = require('../util/preconditions');
 
@@ -9,14 +9,14 @@ var Hash = module.exports;
 
 Hash.sha1 = function(buf) {
   $.checkArgument(BufferUtil.isBuffer(buf));
-  return crypto.createHash('sha1').update(buf).digest();
+  return createHash('sha1').update(buf).digest();
 };
 
 Hash.sha1.blocksize = 512;
 
 Hash.sha256 = function(buf) {
   $.checkArgument(BufferUtil.isBuffer(buf));
-  return crypto.createHash('sha256').update(buf).digest();
+  return createHash('sha256').update(buf).digest();
 };
 
 Hash.sha256.blocksize = 512;
@@ -28,7 +28,7 @@ Hash.sha256sha256 = function(buf) {
 
 Hash.ripemd160 = function(buf) {
   $.checkArgument(BufferUtil.isBuffer(buf));
-  return crypto.createHash('ripemd160').update(buf).digest();
+  return createHash('ripemd160').update(buf).digest();
 };
 
 Hash.sha256ripemd160 = function(buf) {

--- a/lib/crypto/random.js
+++ b/lib/crypto/random.js
@@ -1,37 +1,20 @@
 'use strict';
+var getRandomBytes = require('randombytes');
 
 function Random() {
 }
 
 /* secure random bytes that sometimes throws an error due to lack of entropy */
 Random.getRandomBuffer = function(size) {
-  if (process.browser)
-    return Random.getRandomBufferBrowser(size);
-  else
-    return Random.getRandomBufferNode(size);
+  return getRandomBytes(size);
 };
 
 Random.getRandomBufferNode = function(size) {
-  var crypto = require('crypto');
-  return crypto.randomBytes(size);
+  return this.getRandomBuffer(size);
 };
 
 Random.getRandomBufferBrowser = function(size) {
-  if (!window.crypto && !window.msCrypto)
-    throw new Error('window.crypto not available');
-
-  if (window.crypto && window.crypto.getRandomValues)
-    var crypto = window.crypto;
-  else if (window.msCrypto && window.msCrypto.getRandomValues) //internet explorer
-    var crypto = window.msCrypto;
-  else
-    throw new Error('window.crypto.getRandomValues not available');
-
-  var bbuf = new Uint8Array(size);
-  crypto.getRandomValues(bbuf);
-  var buf = new Buffer(bbuf);
-
-  return buf;
+  return this.getRandomBuffer(size);
 };
 
 /* insecure random bytes, but it never fails */

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -17,6 +17,28 @@
       "from": "buffer-compare@=1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-compare/-/buffer-compare-1.0.0.tgz"
     },
+    "create-hash": {
+      "version": "1.1.2",
+      "from": "create-hash@=1.1.2",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz",
+      "dependencies": {
+        "cipher-base": {
+          "version": "1.0.2",
+          "from": "cipher-base@=1.0.2",
+          "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+        },
+        "ripemd160": {
+          "version": "1.0.1",
+          "from": "ripemd160@=1.0.1",
+          "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz"
+        },
+        "sha.js": {
+          "version": "2.4.4",
+          "from": "sha.js@=2.4.4",
+          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.4.tgz"
+        }
+      }
+    },
     "elliptic": {
       "version": "3.0.3",
       "from": "elliptic@=3.0.3",
@@ -24,7 +46,7 @@
       "dependencies": {
         "brorand": {
           "version": "1.0.5",
-          "from": "brorand@^1.0.1",
+          "from": "brorand@=1.0.1",
           "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
         },
         "hash.js": {
@@ -43,6 +65,11 @@
       "version": "3.10.1",
       "from": "lodash@=3.10.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+    },
+    "randombytes": {
+      "version": "2.0.2",
+      "from": "randombytes@=2.0.2",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.2.tgz"
     },
     "sha512": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -83,9 +83,11 @@
     "bn.js": "=2.0.4",
     "bs58": "=2.0.0",
     "buffer-compare": "=1.0.0",
+    "create-hash": "=1.1.2",
     "elliptic": "=3.0.3",
     "inherits": "=2.0.1",
     "lodash": "=3.10.1",
+    "randombytes": "=2.0.2",
     "sha512": "=0.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Related issue: #43 

|  | bitcore-lib.js | bitcore-lib.min.js |
| :-: | :-: | :-: |
| old | 1523428 | 610621 |
| new | 1193748 | 420662 |
| change | -22% | -31% |

[create-hash](https://github.com/crypto-browserify/createHash) and [randombytes](https://github.com/crypto-browserify/randombytes) will be used in any case by `browserify` through [crypto-browserify](https://github.com/crypto-browserify/crypto-browserify)
