### PR TITLE
Improvements to data contained in error string for signatures in script

### DIFF
--- a/lib/script/interpreter.js
+++ b/lib/script/interpreter.js
@@ -1108,9 +1108,13 @@ Interpreter.prototype.step = function() {
             return false;
           }
 
+          var additional_err = ""
           try {
+            additional_err = "Signature Decode Error"
             sig = Signature.fromTxFormat(bufSig);
+            additional_err = "PublicKey Decode Error"
             pubkey = PublicKey.fromBuffer(bufPubkey, false);
+            additional_err = "Signature Verifcation Error"
             fSuccess = this.tx.verifySignature(sig, pubkey, this.nin, subscript);
           } catch (e) {
             //invalid sig or pubkey
@@ -1118,14 +1122,14 @@ Interpreter.prototype.step = function() {
           }
 
           this.stack.pop();
-          this.stack.pop();
+          this.stack.pop();``
           // stack.push_back(fSuccess ? vchTrue : vchFalse);
           this.stack.push(fSuccess ? Interpreter.true : Interpreter.false);
           if (opcodenum === Opcode.OP_CHECKSIGVERIFY) {
             if (fSuccess) {
               this.stack.pop();
             } else {
-              this.errstr = 'SCRIPT_ERR_CHECKSIGVERIFY';
+              this.errstr = 'SCRIPT_ERR_CHECKSIGVERIFY:'+ additional_err;
               return false;
             }
           }
@@ -1193,6 +1197,9 @@ Interpreter.prototype.step = function() {
             bufPubkey = this.stack[this.stack.length - ikey];
 
             if (!this.checkSignatureEncoding(bufSig) || !this.checkPubkeyEncoding(bufPubkey)) {
+              if (opcodenum === Opcode.OP_CHECKMULTISIGVERIFY) {
+                this.errstr = 'SCRIPT_ERR_CHECKMULTISIGVERIFY:'+"PublicKey or Signature Encoding error";
+              }
               return false;
             }
 


### PR DESCRIPTION
When developing sigScripts, I frequently find myself inserting additional log statements to get a better idea of what exactly is failing in the verification. I'm proposing an approach to increasing the granularity of information available in errstring when verifying a sigScript.