### PR TITLE
Fix wrong property name in docs (Address.Pay2PubKeyHash)

### DIFF
--- a/docs/address.md
+++ b/docs/address.md
@@ -50,7 +50,7 @@ if (Address.isValid(input, Networks.testnet){
 }
 
 // validate that an input field is a valid livenet pubkeyhash
-if (Address.isValid(input, Networks.livenet, Address.Pay2PubKeyHash){
+if (Address.isValid(input, Networks.livenet, Address.PayToPublicKeyHash){
   ...
 }
 


### PR DESCRIPTION
Hi,

There is no `Address.Pay2PubKeyHash` property, instead it's `Address.PayToPublicKeyHash`.