### PR TITLE
crypto: switch to Node.js sha512

### DIFF
--- a/lib/crypto/hash.js
+++ b/lib/crypto/hash.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var sha512 = require('sha512');
 var crypto = require('crypto');
 var BufferUtil = require('../util/buffer');
 var $ = require('../util/preconditions');
@@ -38,8 +37,7 @@ Hash.sha256ripemd160 = function(buf) {
 
 Hash.sha512 = function(buf) {
   $.checkArgument(BufferUtil.isBuffer(buf));
-  var hash = sha512(buf);
-  return new Buffer(hash);
+  return crypto.createHash('sha512').update(buf).digest();
 };
 
 Hash.sha512.blocksize = 1024;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -43,11 +43,6 @@
       "version": "3.10.1",
       "from": "lodash@=3.10.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-    },
-    "sha512": {
-      "version": "0.0.1",
-      "from": "sha512@=0.0.1",
-      "resolved": "https://registry.npmjs.org/sha512/-/sha512-0.0.1.tgz"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -85,8 +85,7 @@
     "buffer-compare": "=1.0.0",
     "elliptic": "=3.0.3",
     "inherits": "=2.0.1",
-    "lodash": "=3.10.1",
-    "sha512": "=0.0.1"
+    "lodash": "=3.10.1"
   },
   "devDependencies": {
     "bitcore-build": "bitpay/bitcore-build",


### PR DESCRIPTION
The sha512 library has not been updated in quite some time. This switches to
use Node.js crypto for sha512 that will use crypto-browserify, and more
recently maintained sha.js for the browser build.