### PR TITLE
nodejs v6 testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,8 @@ report
 .DS_Store
 
 
-bitcore.js
-bitcore.min.js
-bitcore.js.sig
-bitcore.min.js.sig
+bitcore-lib.js
+bitcore-lib.min.js
+bitcore-lib.js.sig
+bitcore-lib.min.js.sig
 tests.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,16 @@
 language: node_js
 sudo: false
+compiler:
+  - gcc
+  - clang
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - gcc-4.8
+    - g++-4.8
+    - clang
 node_js:
 - '0.10'
 - '0.12'
@@ -7,6 +18,7 @@ node_js:
 - '4'
 - '6'
 before_install:
+  - export CXX="g++-4.8" CC="gcc-4.8"
   - npm install -g bower
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
 - '0.12'
 - '2.0.0'
 - '4'
+- '6'
 before_install:
   - npm install -g bower
   - export DISPLAY=:99.0

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "lodash": "=3.10.1"
   },
   "devDependencies": {
-    "bitcore-build": "bitpay/bitcore-build",
+    "bitcore-build": "braydonf/bitcore-build#abeaa87ad3b1707cf1f2bcded5126a6d0b07658c",
     "brfs": "^1.2.0",
     "chai": "^1.10.0",
     "gulp": "^3.8.10",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,8 @@
     "chai": "^1.10.0",
     "gulp": "^3.8.10",
     "karma": "^0.13.22",
+    "karma-firefox-launcher": "^1.0.0",
+    "karma-mocha": "^1.0.1",
     "sinon": "^1.13.0"
   },
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
   "devDependencies": {
     "bitcore-build": "braydonf/bitcore-build#abeaa87ad3b1707cf1f2bcded5126a6d0b07658c",
     "brfs": "^1.2.0",
+    "browserify": "^13.0.1",
     "chai": "^1.10.0",
     "gulp": "^3.8.10",
     "sinon": "^1.13.0"

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "browserify": "^13.0.1",
     "chai": "^1.10.0",
     "gulp": "^3.8.10",
+    "karma": "^0.13.22",
     "sinon": "^1.13.0"
   },
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -93,9 +93,11 @@
     "browserify": "^13.0.1",
     "chai": "^1.10.0",
     "gulp": "^3.8.10",
+    "istanbul": "^0.4.3",
     "karma": "^0.13.22",
     "karma-firefox-launcher": "^1.0.0",
     "karma-mocha": "^1.0.1",
+    "mocha": "^2.5.3",
     "sinon": "^1.13.0"
   },
   "license": "MIT"


### PR DESCRIPTION
All tests are passing locally, only small change to the locations of browserify and etc. needed to be updated in bitcore-build.

Closes: https://github.com/bitpay/bitcore-lib/issues/62
