### PR TITLE
transaction: update serialization skip docs

### DIFF
--- a/lib/transaction/transaction.js
+++ b/lib/transaction/transaction.js
@@ -165,8 +165,8 @@ Transaction.prototype.uncheckedSerialize = Transaction.prototype.toString = func
 Transaction.prototype.checkedSerialize = function(opts) {
   var serializationError = this.getSerializationError(opts);
   if (serializationError) {
-    serializationError.message += ' Use Transaction#uncheckedSerialize if you want to skip security checks. ' +
-      'See http://bitcore.io/guide/transaction.html#Serialization for more info.';
+    serializationError.message += ' - For more information please see: ' +
+      'https://bitcore.io/api/lib/transaction#serialization-checks';
     throw serializationError;
   }
   return this.uncheckedSerialize();


### PR DESCRIPTION
Emphasis selectively disabling security checks vs using `uncheckedSerialize`, and update link to serialization check documentation to: https://bitcore.io/api/lib/transaction#serialization-checks
