### PR TITLE
Feature/merkleblock add txs that match filter

### DIFF
--- a/lib/block/merkleblock.js
+++ b/lib/block/merkleblock.js
@@ -155,7 +155,7 @@ MerkleBlock.prototype.validMerkleTree = function validMerkleTree() {
  * Return a list of all the txs hash that match the filter
  * @returns {Array} - txs hash that match the filter
  */
-MerkleBlock.prototype.filterdTxsHash = function validMerkleTree() {
+MerkleBlock.prototype.filterdTxsHash = function filterdTxsHash() {
   $.checkState(_.isArray(this.flags), 'MerkleBlock flags is not an array');
   $.checkState(_.isArray(this.hashes), 'MerkleBlock hashes is not an array');
 
@@ -168,6 +168,11 @@ MerkleBlock.prototype.filterdTxsHash = function validMerkleTree() {
   if(this.flags.length * 8 < this.hashes.length) {
     throw new errors.MerkleBlock.InvalidMerkleTree();
   }
+
+  // If there is only one hash the filter do not match any txs in the block
+  if(this.hashes.length === 1) {
+    return [];
+  };
 
   var height = this._calcTreeHeight();
   var opts = { hashesUsed: 0, flagBitsUsed: 0 };

--- a/lib/block/merkleblock.js
+++ b/lib/block/merkleblock.js
@@ -8,6 +8,7 @@ var BufferWriter = require('../encoding/bufferwriter');
 var Hash = require('../crypto/hash');
 var JSUtil = require('../util/js');
 var Transaction = require('../transaction');
+var errors = require('../errors');
 var $ = require('../util/preconditions');
 
 /**
@@ -63,6 +64,7 @@ function MerkleBlock(arg) {
   _.extend(this,info);
   this._flagBitsUsed = 0;
   this._hashesUsed = 0;
+
   return this;
 }
 
@@ -150,18 +152,47 @@ MerkleBlock.prototype.validMerkleTree = function validMerkleTree() {
 };
 
 /**
+ * Return a list of all the txs hash that match the filter
+ * @returns {Array} - txs hash that match the filter
+ */
+MerkleBlock.prototype.filterdTxsHash = function validMerkleTree() {
+  $.checkState(_.isArray(this.flags), 'MerkleBlock flags is not an array');
+  $.checkState(_.isArray(this.hashes), 'MerkleBlock hashes is not an array');
+
+  // Can't have more hashes than numTransactions
+  if(this.hashes.length > this.numTransactions) {
+    throw new errors.MerkleBlock.InvalidMerkleTree();
+  }
+
+  // Can't have more flag bits than num hashes
+  if(this.flags.length * 8 < this.hashes.length) {
+    throw new errors.MerkleBlock.InvalidMerkleTree();
+  }
+
+  var height = this._calcTreeHeight();
+  var opts = { hashesUsed: 0, flagBitsUsed: 0 };
+  var txs = this._traverseMerkleTree(height, 0, opts, true);
+  if(opts.hashesUsed !== this.hashes.length) {
+    throw new errors.MerkleBlock.InvalidMerkleTree();
+  }
+  return txs;
+};
+
+/**
  * Traverse a the tree in this MerkleBlock, validating it along the way
  * Modeled after Bitcoin Core merkleblock.cpp TraverseAndExtract()
  * @param {Number} - depth - Current height
  * @param {Number} - pos - Current position in the tree
  * @param {Object} - opts - Object with values that need to be mutated throughout the traversal
+ * @param {Boolean} - checkForTxs - if true return opts.txs else return the Merkle Hash
  * @param {Number} - opts.flagBitsUsed - Number of flag bits used, should start at 0
  * @param {Number} - opts.hashesUsed - Number of hashes used, should start at 0
- * @param {Array} - opts.txs - Will finish populated by transactions found during traversal
+ * @param {Array} - opts.txs - Will finish populated by transactions found during traversal that match the filter
  * @returns {Buffer|null} - Buffer containing the Merkle Hash for that height
+ * @returns {Array} - transactions found during traversal that match the filter
  * @private
  */
-MerkleBlock.prototype._traverseMerkleTree = function traverseMerkleTree(depth, pos, opts) {
+MerkleBlock.prototype._traverseMerkleTree = function traverseMerkleTree(depth, pos, opts, checkForTxs) {
   /* jshint maxcomplexity:  12*/
   /* jshint maxstatements: 20 */
 
@@ -169,6 +200,7 @@ MerkleBlock.prototype._traverseMerkleTree = function traverseMerkleTree(depth, p
   opts.txs = opts.txs || [];
   opts.flagBitsUsed = opts.flagBitsUsed || 0;
   opts.hashesUsed = opts.hashesUsed || 0;
+  var checkForTxs = checkForTxs || false;
 
   if(opts.flagBitsUsed > this.flags.length * 8) {
     return null;
@@ -189,7 +221,11 @@ MerkleBlock.prototype._traverseMerkleTree = function traverseMerkleTree(depth, p
     if(pos*2+1 < this._calcTreeWidth(depth-1)) {
       right = this._traverseMerkleTree(depth-1, pos*2+1, opts);
     }
-    return Hash.sha256sha256(new Buffer.concat([left, right]));
+    if (checkForTxs){
+      return opts.txs;
+    } else {
+      return Hash.sha256sha256(new Buffer.concat([left, right]));
+    };
   }
 };
 

--- a/lib/errors/spec.js
+++ b/lib/errors/spec.js
@@ -45,6 +45,13 @@ module.exports = [{
     'message': 'Invalid exchange rate: {0}'
   }]
 }, {
+  name: 'MerkleBlock',
+  message: 'Internal Error on MerkleBlock {0}',
+  errors: [{
+    'name': 'InvalidMerkleTree',
+    'message': 'This MerkleBlock contain an invalid Merkle Tree'
+  }]
+}, {
   name: 'Transaction',
   message: 'Internal Error on Transaction {0}',
   errors: [{

--- a/test/block/merkleblock.js
+++ b/test/block/merkleblock.js
@@ -152,6 +152,36 @@ describe('MerkleBlock', function() {
 
   });
 
+  describe('#filterdTxsHash', function() {
+
+    it('should validate good merkleblocks', function() {
+      var hashOfFilteredTx = '6f64fd5aa9dd01f74c03656d376625cf80328d83d9afebe60cc68b8f0e245bd9' 
+      var b = MerkleBlock(data.JSON[3]);
+      b.filterdTxsHash()[0].should.equal(hashOfFilteredTx);
+    });
+
+    it('should fail with merkleblocks with too many hashes', function() {
+      var b = MerkleBlock(data.JSON[0]);
+      // Add too many hashes
+      var i = 0;
+      while(i <= b.numTransactions) {
+        b.hashes.push('bad' + i++);
+      }
+      (function() {
+        b.filterdTxsHash();
+      }).should.throw('This MerkleBlock contain an invalid Merkle Tree');
+    });
+
+    it('should fail with merkleblocks with too few bit flags', function() {
+      var b = MerkleBlock(JSON.parse(blockJSON));
+      b.flags.pop();
+      (function() {
+        b.filterdTxsHash();
+      }).should.throw('This MerkleBlock contain an invalid Merkle Tree');
+    });
+
+  });
+
   describe('#hasTransaction', function() {
 
     it('should find transactions via hash string', function() {

--- a/test/data/merkleblocks.js
+++ b/test/data/merkleblocks.js
@@ -453,6 +453,34 @@ module.exports = {
         nonce : 322045839,
         bits : 419587686,
       }
+    },
+    { // Mainnet FilteredBlock 399775 with filter: 6f64fd5aa9dd01f74c03656d376625cf80328d83d9afebe60cc68b8f0e245bd9
+      "header": {
+      "hash": "0000000000000000011b04bc9f4f3856e299b53a335eb1c42be906237c860bb8",
+      "version": 4,
+      "prevHash": "0000000000000000015373947aa93c7cb16a308fb0a59644d4123072ad24ce5b",
+      "merkleRoot": "ac1841eb3b7d380ee114270e3b1c7df349f1e27e2f0f7891138199bc07e006f8",
+      "time": 1456274787,
+      "bits": 403093919,
+      "nonce": 736568686
+      },
+      "numTransactions": 3309,
+      "hashes": [
+        "adaf1e41a5349a7e2b27e6f2b5fc1186d576d21b47531a410a654439f49bd5a9",
+        "0f64562b6d361757bfdc5926d28cafb7c45e4822b4ad5a14e65530d0c9d44cd2",
+        "c34dec8d5954d8c151c3a594a5a6d1f3a1ec8a1a6c470b27aea879b7757328fb",
+        "c044e5d998fe29cdbe88f87c97c3547f142f5b491cb909d9b0a8e9d3ab7fc984",
+        "51ecd2d2b02b0ca1a3b439eae3adf87ab37dd87f7be0c5b3437cd22350079101",
+        "684ebe37c6eaae2879249ff20b3769d5f2f7ad853a5363a4baee68c0c85777a5",
+        "e561fbeb0faff42f95f2dc8d57d432d4d1a9f84483597a0602e1edc3390f1e33",
+        "02c070afc743c885a6c8d94d15d6e9c3b991c636b4284258dd37686c8792fe44",
+        "6f64fd5aa9dd01f74c03656d376625cf80328d83d9afebe60cc68b8f0e245bd9",
+        "a296fef97b3da0825bac00c794ea234913421b7c1cbb8571978d8d5ba3b16de2",
+        "691c6855c5da434a06cb39a7e47d9337da0e39112ad975cc70cecc882233920a",
+        "6a9e7f8e6d1d8c326a774ff691bdf424252cee710f8e5d9da2c094e999c15efc",
+        "0723ffc695fef989e86784fa2b47097d55f6aac244631536d8d901f5cd9bf170"
+        ],
+      "flags": [171,86,23,0]
     }
   ]
 };


### PR DESCRIPTION
Add method at MerkleBlock that return the txs' hash (in MerkleBlock.hashs) that match the filter (depth === 0 and flag's bit === 1) this is helpful because the txs are send in other messages so the only way for know wich txs match the filter (without knowing the other messages with the txs) is add a specific function to MerkleBlock.

I have used _traverseMerkleTree for check wich txs match the filter for do not duplicate codes.
