### PR TITLE
'ripemd160' to 'rmd160' for compatibility with ' crypto-browserify'

### DIFF
--- a/lib/crypto/hash.js
+++ b/lib/crypto/hash.js
@@ -27,7 +27,7 @@ Hash.sha256sha256 = function(buf) {
 
 Hash.ripemd160 = function(buf) {
   $.checkArgument(BufferUtil.isBuffer(buf));
-  return crypto.createHash('ripemd160').update(buf).digest();
+  return crypto.createHash('rmd160').update(buf).digest();
 };
 
 Hash.sha256ripemd160 = function(buf) {

--- a/lib/privatekey.js
+++ b/lib/privatekey.js
@@ -336,7 +336,7 @@ PrivateKey.prototype.toBigNumber = function(){
  * @returns {Buffer} A buffer of the private key
  */
 PrivateKey.prototype.toBuffer = function(){
-  return this.bn.toBuffer();
+  return this.bn.toBuffer({ size: 32 });
 };
 
 /**

--- a/test/privatekey.js
+++ b/test/privatekey.js
@@ -330,6 +330,13 @@ describe('PrivateKey', function() {
       var fromBuffer = PrivateKey.fromBuffer(toBuffer.toBuffer());
       fromBuffer.toString().should.equal(privkey.toString());
     });
+
+    it('should return buffer with length equal 32', function() {
+      var bn = BN.fromBuffer(buf.slice(0, 31));
+      var privkey = new PrivateKey(bn, 'livenet');
+      var expected = Buffer.concat([ new Buffer([0]), buf.slice(0, 31) ]);
+      privkey.toBuffer().toString('hex').should.equal(expected.toString('hex'));
+    });
   });
 
   describe('#toBigNumber', function() {


### PR DESCRIPTION
Really simple change to be compatible with crypto-browserify. All tests pass with flying colours.
