### PR TITLE
Make Script.getPublicKey work with PublicKeyHashIn scripts

### DIFF
--- a/lib/script/script.js
+++ b/lib/script/script.js
@@ -328,8 +328,12 @@ Script.prototype.isPublicKeyHashIn = function() {
 };
 
 Script.prototype.getPublicKey = function() {
-  $.checkState(this.isPublicKeyOut(), 'Can\'t retrieve PublicKey from a non-PK output');
-  return this.chunks[0].buf;
+  if (this.isPublicKeyOut()) {
+    return this.chunks[0].buf;
+  } else if (this.isPublicKeyHashIn()) {
+    return this.chunks[1].buf;
+  }
+  throw new errors.InvalidState('Can\'t retrieve PublicKey from a non-PK output or PKH input');
 };
 
 Script.prototype.getPublicKeyHash = function() {


### PR DESCRIPTION
The `Script.getPublicKey` function is not documented, so I don't know if it is part of the public API.

If you are interested, I can add unit tests.
