### PR TITLE
Bip32fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: node_js
 sudo: false
 node_js:
-- '0.10'
-- '0.12'
-- '2.0.0'
 - '4'
 before_install:
   - npm install -g bower

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**Note**: This is a development/staging branch for 1.0.0
+
 Bitcore Library
 =======
 

--- a/docs/hierarchical.md
+++ b/docs/hierarchical.md
@@ -15,9 +15,9 @@ var HDPrivateKey = bitcore.HDPrivateKey;
 
 var hdPrivateKey = new HDPrivateKey();
 var retrieved = new HDPrivateKey('xpriv...');
-var derived = hdPrivateKey.derive("m/0'");
-var derivedByNumber = hdPrivateKey.derive(1).derive(2, true);
-var derivedByArgument = hdPrivateKey.derive("m/1/2'");
+var derived = hdPrivateKey.getChild("m/0'");
+var derivedByNumber = hdPrivateKey.getChild(1).getChild(2, true);
+var derivedByArgument = hdPrivateKey.getChild("m/1/2'");
 assert(derivedByNumber.xprivkey === derivedByArgument.xprivkey);
 
 var address = derived.privateKey.toAddress();
@@ -39,5 +39,5 @@ try {
 }
 
 var address = new Address(hdPublicKey.publicKey, Networks.livenet);
-var derivedAddress = new Address(hdPublicKey.derive(100).publicKey, Networks.testnet);
+var derivedAddress = new Address(hdPublicKey.getChild(100).publicKey, Networks.testnet);
 ```

--- a/lib/hdkeycache.js
+++ b/lib/hdkeycache.js
@@ -8,17 +8,17 @@ module.exports = {
   _usedIndex: {},
   _CACHE_SIZE: 5000,
 
-  get: function(xkey, number, hardened) {
+  get: function(xkey, number, hardened, nonCompliant) {
     hardened = !!hardened;
-    var key = xkey + '/' + number + '/' + hardened;
+    var key = (nonCompliant ? '1' : '0') + xkey + '/' + number + '/' + hardened;
     if (this._cache[key]) {
       this._cacheHit(key);
       return this._cache[key];
     }
   },
-  set: function(xkey, number, hardened, derived) {
+  set: function(xkey, number, hardened, derived, nonCompliant) {
     hardened = !!hardened;
-    var key = xkey + '/' + number + '/' + hardened;
+    var key =  (nonCompliant ? '1' : '0') + xkey + '/' + number + '/' + hardened;
     this._cache[key] = derived;
     this._cacheHit(key);
   },

--- a/lib/hdprivatekey.js
+++ b/lib/hdprivatekey.js
@@ -225,6 +225,11 @@ HDPrivateKey.prototype._deriveWithNumber = function(index, hardened, nonComplian
     size: 32
   });
 
+  if (!PrivateKey.isValid(privateKey)) {
+    // Index at this point is already hardened, we can pass null as the hardened arg
+    return this._deriveWithNumber(index + 1, null, nonCompliant);
+  }
+
   var derived = new HDPrivateKey({
     network: this.network,
     depth: this.depth + 1,

--- a/lib/hdprivatekey.js
+++ b/lib/hdprivatekey.js
@@ -139,6 +139,9 @@ HDPrivateKey._getDerivationIndexes = function(path) {
  * derived. If the second argument is truthy, the hardened version will be
  * derived. See the example usage for clarification.
  *
+ * WARNING: The `nonCompliant` option should NOT be used, except for older implementation
+ * that used a derivation strategy that used a non-zero padded private key.
+ *
  * @example
  * ```javascript
  * var parent = new HDPrivateKey('xprv...');
@@ -149,18 +152,38 @@ HDPrivateKey._getDerivationIndexes = function(path) {
  *
  * @param {string|number} arg
  * @param {boolean?} hardened
+ * @param {boolean?} nonCompliant - This should not be used and only for backwards compatibility
+ *
  */
-HDPrivateKey.prototype.derive = function(arg, hardened) {
+HDPrivateKey.prototype.derive = function(arg, hardened, nonCompliant) {
   if (_.isNumber(arg)) {
-    return this._deriveWithNumber(arg, hardened);
+    return this._deriveWithNumber(arg, hardened, nonCompliant);
   } else if (_.isString(arg)) {
-    return this._deriveFromString(arg);
+    return this._deriveFromString(arg, nonCompliant);
   } else {
     throw new hdErrors.InvalidDerivationArgument(arg);
   }
 };
 
-HDPrivateKey.prototype._deriveWithNumber = function(index, hardened) {
+/**
+ * WARNING: If this is a new implementation you should NOT use this method, you should be using
+ * `derive` instead.
+ *
+ * This method is explicitly for use and compatibility with an implementation that
+ * was not compliant with BIP32 regarding the derivation algorithm. The private key
+ * must be 32 bytes hashing, and this implementation will use the non-zero padded
+ * serialization of a private key, such that it's still possible to derive the privateKey
+ * to recover those funds.
+ *
+ * @param {string|number} arg
+ * @param {boolean?} hardened
+ */
+HDPrivateKey.prototype.deriveNonCompliant = function(arg, hardened) {
+  var derived = this.derive(arg, hardened, true);
+  return derived;
+};
+
+HDPrivateKey.prototype._deriveWithNumber = function(index, hardened, nonCompliant) {
   /* jshint maxstatements: 20 */
   /* jshint maxcomplexity: 10 */
   if (!HDPrivateKey.isValidPath(index, hardened)) {
@@ -172,15 +195,23 @@ HDPrivateKey.prototype._deriveWithNumber = function(index, hardened) {
     index += HDPrivateKey.Hardened;
   }
 
-  var cached = HDKeyCache.get(this.xprivkey, index, hardened);
+  var cached = HDKeyCache.get(this.xprivkey, index, hardened, nonCompliant);
   if (cached) {
     return cached;
   }
 
   var indexBuffer = BufferUtil.integerAsBuffer(index);
   var data;
-  if (hardened) {
-    data = BufferUtil.concat([new buffer.Buffer([0]), this.privateKey.toBuffer(), indexBuffer]);
+  if (hardened && nonCompliant) {
+    // The private key serialization in this case will not be exactly 32 bytes and can be
+    // any value less, and the value is not zero-padded.
+    var nonZeroPadded = this.privateKey.bn.toBuffer();
+    data = BufferUtil.concat([new buffer.Buffer([0]), nonZeroPadded, indexBuffer]);
+  } else if (hardened) {
+    // This will use a 32 byte zero padded serialization of the private key
+    var privateKeyBuffer = this.privateKey.bn.toBuffer({size: 32});
+    assert(privateKeyBuffer.length === 32, 'length of private key buffer is expected to be 32 bytes');
+    data = BufferUtil.concat([new buffer.Buffer([0]), privateKeyBuffer, indexBuffer]);
   } else {
     data = BufferUtil.concat([this.publicKey.toBuffer(), indexBuffer]);
   }
@@ -202,18 +233,18 @@ HDPrivateKey.prototype._deriveWithNumber = function(index, hardened) {
     chainCode: chainCode,
     privateKey: privateKey
   });
-  HDKeyCache.set(this.xprivkey, index, hardened, derived);
+  HDKeyCache.set(this.xprivkey, index, hardened, derived, nonCompliant);
   return derived;
 };
 
-HDPrivateKey.prototype._deriveFromString = function(path) {
+HDPrivateKey.prototype._deriveFromString = function(path, nonCompliant) {
   if (!HDPrivateKey.isValidPath(path)) {
     throw new hdErrors.InvalidPath(path);
   }
 
   var indexes = HDPrivateKey._getDerivationIndexes(path);
   var derived = indexes.reduce(function(prev, index) {
-    return prev._deriveWithNumber(index);
+    return prev._deriveWithNumber(index, null, nonCompliant);
   }, this);
 
   return derived;

--- a/lib/hdprivatekey.js
+++ b/lib/hdprivatekey.js
@@ -127,6 +127,7 @@ HDPrivateKey._getDerivationIndexes = function(path) {
   return _.any(indexes, isNaN) ? null : indexes;
 };
 
+
 /**
  * Get a derived child based on a string or number.
  *
@@ -156,6 +157,11 @@ HDPrivateKey._getDerivationIndexes = function(path) {
  *
  */
 HDPrivateKey.prototype.derive = function(arg, hardened, nonCompliant) {
+
+  // Defaults to the nonCompliant derivation, for backwards compatibility
+  if (_.isUndefined(nonCompliant))
+    nonCompliant = true;
+
   if (_.isNumber(arg)) {
     return this._deriveWithNumber(arg, hardened, nonCompliant);
   } else if (_.isString(arg)) {
@@ -165,9 +171,70 @@ HDPrivateKey.prototype.derive = function(arg, hardened, nonCompliant) {
   }
 };
 
+
+
+/**
+ *
+ * WARNING: This method should not be called directly. Please use: `getChild` or `getNonCompliantChild'.
+ *
+ * Internal method to get a derived child based on a string or number.
+ *
+ * @param {string|number} arg
+ * @param {boolean?} hardened
+ * @param {boolean?} nonCompliant - This should not be used and only for backwards compatibility
+ *
+ */
+HDPrivateKey.prototype.derive = function(arg, hardened, nonCompliant) {
+
+  // Defaults to the nonCompliant derivation, for backwards compatibility
+  if (_.isUndefined(nonCompliant)) {
+    console.log('Warning: Using no BIP32 Compliant key derivation. If this is on purpose, use `getNonCompliantChild` to avoid this warning, otherwise use the `getChild`')
+    nonCompliant = true;
+  }
+
+  if (_.isNumber(arg)) {
+    return this._deriveWithNumber(arg, hardened, nonCompliant);
+  } else if (_.isString(arg)) {
+    return this._deriveFromString(arg, nonCompliant);
+  } else {
+    throw new hdErrors.InvalidDerivationArgument(arg);
+  }
+};
+
+
+/**
+ * Get a derived child based on a string or number.
+ *
+ * If the first argument is a string, it's parsed as the full path of
+ * derivation. Valid values for this argument include "m" (which returns the
+ * same private key), "m/0/1/40/2'/1000", where the ' quote means a hardened
+ * derivation.
+ *
+ * If the first argument is a number, the child with that index will be
+ * derived. If the second argument is truthy, the hardened version will be
+ * derived. See the example usage for clarification.
+ *
+ * @example
+ * ```javascript
+ * var parent = new HDPrivateKey('xprv...');
+ * var child_0_1_2h = parent.getChild(0).getChild(1).getChild(2, true);
+ * var copy_of_child_0_1_2h = parent.getChild("m/0/1/2'");
+ * assert(child_0_1_2h.xprivkey === copy_of_child_0_1_2h);
+ * ```
+ *
+ * @param {string|number} arg
+ * @param {boolean?} hardened
+ *
+ */
+
+HDPrivateKey.prototype.getChild = function(arg, hardened) {
+  var derived = this.derive(arg, hardened, false);
+  return derived;
+};
+
 /**
  * WARNING: If this is a new implementation you should NOT use this method, you should be using
- * `derive` instead.
+ * `getChild` instead.
  *
  * This method is explicitly for use and compatibility with an implementation that
  * was not compliant with BIP32 regarding the derivation algorithm. The private key
@@ -178,7 +245,7 @@ HDPrivateKey.prototype.derive = function(arg, hardened, nonCompliant) {
  * @param {string|number} arg
  * @param {boolean?} hardened
  */
-HDPrivateKey.prototype.deriveNonCompliant = function(arg, hardened) {
+HDPrivateKey.prototype.getNonCompliantChild = function(arg, hardened) {
   var derived = this.derive(arg, hardened, true);
   return derived;
 };
@@ -209,7 +276,9 @@ HDPrivateKey.prototype._deriveWithNumber = function(index, hardened, nonComplian
     data = BufferUtil.concat([new buffer.Buffer([0]), nonZeroPadded, indexBuffer]);
   } else if (hardened) {
     // This will use a 32 byte zero padded serialization of the private key
-    var privateKeyBuffer = this.privateKey.bn.toBuffer({size: 32});
+    var privateKeyBuffer = this.privateKey.bn.toBuffer({
+      size: 32
+    });
     assert(privateKeyBuffer.length === 32, 'length of private key buffer is expected to be 32 bytes');
     data = BufferUtil.concat([new buffer.Buffer([0]), privateKeyBuffer, indexBuffer]);
   } else {

--- a/lib/hdprivatekey.js
+++ b/lib/hdprivatekey.js
@@ -129,31 +129,8 @@ HDPrivateKey._getDerivationIndexes = function(path) {
 
 
 /**
- * Get a derived child based on a string or number.
  *
- * If the first argument is a string, it's parsed as the full path of
- * derivation. Valid values for this argument include "m" (which returns the
- * same private key), "m/0/1/40/2'/1000", where the ' quote means a hardened
- * derivation.
- *
- * If the first argument is a number, the child with that index will be
- * derived. If the second argument is truthy, the hardened version will be
- * derived. See the example usage for clarification.
- *
- * WARNING: The `nonCompliant` option should NOT be used, except for older implementation
- * that used a derivation strategy that used a non-zero padded private key.
- *
- * @example
- * ```javascript
- * var parent = new HDPrivateKey('xprv...');
- * var child_0_1_2h = parent.derive(0).derive(1).derive(2, true);
- * var copy_of_child_0_1_2h = parent.derive("m/0/1/2'");
- * assert(child_0_1_2h.xprivkey === copy_of_child_0_1_2h);
- * ```
- *
- * @param {string|number} arg
- * @param {boolean?} hardened
- * @param {boolean?} nonCompliant - This should not be used and only for backwards compatibility
+ * Get a derived child based on a string or number. This method should not be called directly. Please use: `getChild` or `getNonCompliantChild'.
  *
  */
 HDPrivateKey.prototype.derive = function(arg, hardened, nonCompliant) {
@@ -170,6 +147,9 @@ HDPrivateKey.prototype.derive = function(arg, hardened, nonCompliant) {
     throw new hdErrors.InvalidDerivationArgument(arg);
   }
 };
+
+
+
 
 
 /**

--- a/lib/hdprivatekey.js
+++ b/lib/hdprivatekey.js
@@ -172,36 +172,6 @@ HDPrivateKey.prototype.derive = function(arg, hardened, nonCompliant) {
 };
 
 
-
-/**
- *
- * WARNING: This method should not be called directly. Please use: `getChild` or `getNonCompliantChild'.
- *
- * Internal method to get a derived child based on a string or number.
- *
- * @param {string|number} arg
- * @param {boolean?} hardened
- * @param {boolean?} nonCompliant - This should not be used and only for backwards compatibility
- *
- */
-HDPrivateKey.prototype.derive = function(arg, hardened, nonCompliant) {
-
-  // Defaults to the nonCompliant derivation, for backwards compatibility
-  if (_.isUndefined(nonCompliant)) {
-    console.log('WARN: .derive will be removed in next Bitcore-lib releases.  Use `getChild` for BIP32 Compliant key derivation and `getNonCompliantChild` for backwards compatibility key derivation. Details at https://github.com/bitpay/bitcore-lib/pull/115')
-    nonCompliant = true;
-  }
-
-  if (_.isNumber(arg)) {
-    return this._deriveWithNumber(arg, hardened, nonCompliant);
-  } else if (_.isString(arg)) {
-    return this._deriveFromString(arg, nonCompliant);
-  } else {
-    throw new hdErrors.InvalidDerivationArgument(arg);
-  }
-};
-
-
 /**
  * Get a derived child based on a string or number.
  *

--- a/lib/hdprivatekey.js
+++ b/lib/hdprivatekey.js
@@ -188,7 +188,7 @@ HDPrivateKey.prototype.derive = function(arg, hardened, nonCompliant) {
 
   // Defaults to the nonCompliant derivation, for backwards compatibility
   if (_.isUndefined(nonCompliant)) {
-    console.log('Warning: Using no BIP32 Compliant key derivation. If this is on purpose, use `getNonCompliantChild` to avoid this warning, otherwise use the `getChild`')
+    console.log('WARN: .derive will be removed in next Bitcore-lib releases.  Use `getChild` for BIP32 Compliant key derivation and `getNonCompliantChild` for backwards compatibility key derivation. Details at https://github.com/bitpay/bitcore-lib/pull/115')
     nonCompliant = true;
   }
 

--- a/lib/hdpublickey.js
+++ b/lib/hdpublickey.js
@@ -136,7 +136,12 @@ HDPublicKey.prototype._deriveWithNumber = function(index, hardened) {
   var leftPart = BN.fromBuffer(hash.slice(0, 32), {size: 32});
   var chainCode = hash.slice(32, 64);
 
-  var publicKey = PublicKey.fromPoint(Point.getG().mul(leftPart).add(this.publicKey.point));
+  var publicKey;
+  try {
+    publicKey = PublicKey.fromPoint(Point.getG().mul(leftPart).add(this.publicKey.point));
+  } catch (e) {
+    return this._deriveWithNumber(index + 1);
+  }
 
   var derived = new HDPublicKey({
     network: this.network,

--- a/lib/hdpublickey.js
+++ b/lib/hdpublickey.js
@@ -86,6 +86,22 @@ HDPublicKey.isValidPath = function(arg) {
   return false;
 };
 
+
+/**
+ * Internal method to get a derivated child based on a string or number.
+ *
+ */
+ 
+HDPublicKey.prototype.derive = function(arg, hardened) {
+  if (_.isNumber(arg)) {
+    return this._deriveWithNumber(arg, hardened);
+  } else if (_.isString(arg)) {
+    return this._deriveFromString(arg);
+  } else {
+    throw new hdErrors.InvalidDerivationArgument(arg);
+  }
+};
+
 /**
  * Get a derivated child based on a string or number.
  *
@@ -108,14 +124,8 @@ HDPublicKey.isValidPath = function(arg) {
  *
  * @param {string|number} arg
  */
-HDPublicKey.prototype.derive = function(arg, hardened) {
-  if (_.isNumber(arg)) {
-    return this._deriveWithNumber(arg, hardened);
-  } else if (_.isString(arg)) {
-    return this._deriveFromString(arg);
-  } else {
-    throw new hdErrors.InvalidDerivationArgument(arg);
-  }
+HDPublicKey.prototype.getChild = function(arg, hardened) {
+  return this.derive(arg, hardened);
 };
 
 HDPublicKey.prototype._deriveWithNumber = function(index, hardened) {

--- a/lib/privatekey.js
+++ b/lib/privatekey.js
@@ -336,7 +336,7 @@ PrivateKey.prototype.toBigNumber = function(){
  * @returns {Buffer} A buffer of the private key
  */
 PrivateKey.prototype.toBuffer = function(){
-  return this.bn.toBuffer();
+  return this.bn.toBuffer({ size: 32 });
 };
 
 /**

--- a/lib/privatekey.js
+++ b/lib/privatekey.js
@@ -340,6 +340,15 @@ PrivateKey.prototype.toBuffer = function(){
 };
 
 /**
+ * Will return the private key as a BN buffer without leading zero padding
+ *
+ * @returns {Buffer} A buffer of the private key
+ */
+PrivateKey.prototype.toBufferNoPadding = function() {
+  return this.bn.toBuffer();
+};
+
+/**
  * Will return the corresponding public key
  *
  * @returns {PublicKey} A public key generated from the private key

--- a/test/hdkeycache.js
+++ b/test/hdkeycache.js
@@ -25,22 +25,22 @@ describe('HDKey cache', function() {
 
   it('saves a derived key', function() {
     var child = master.derive(0);
-    expect(cache._cache[master.xprivkey + '/0/false'].xprivkey).to.equal(child.xprivkey);
+    expect(cache._cache['0' + master.xprivkey + '/0/false'].xprivkey).to.equal(child.xprivkey);
   });
   it('starts erasing unused keys', function() {
     var child1 = master.derive(0);
     var child2 = child1.derive(0);
     var child3 = child2.derive(0);
-    expect(cache._cache[master.xprivkey + '/0/false'].xprivkey).to.equal(child1.xprivkey);
+    expect(cache._cache['0' + master.xprivkey + '/0/false'].xprivkey).to.equal(child1.xprivkey);
     var child4 = child3.derive(0);
-    expect(cache._cache[master.xprivkey + '/0/false']).to.equal(undefined);
+    expect(cache._cache['0' + master.xprivkey + '/0/false']).to.equal(undefined);
   });
   it('avoids erasing keys that get cache hits ("hot keys")', function() {
     var child1 = master.derive(0);
     var child2 = master.derive(0).derive(0);
-    expect(cache._cache[master.xprivkey + '/0/false'].xprivkey).to.equal(child1.xprivkey);
+    expect(cache._cache['0' + master.xprivkey + '/0/false'].xprivkey).to.equal(child1.xprivkey);
     var child1_copy = master.derive(0);
-    expect(cache._cache[master.xprivkey + '/0/false'].xprivkey).to.equal(child1.xprivkey);
+    expect(cache._cache['0' + master.xprivkey + '/0/false'].xprivkey).to.equal(child1.xprivkey);
   });
   it('keeps the size of the cache small', function() {
     var child1 = master.derive(0);

--- a/test/hdkeycache.js
+++ b/test/hdkeycache.js
@@ -24,29 +24,29 @@ describe('HDKey cache', function() {
   });
 
   it('saves a derived key', function() {
-    var child = master.derive(0);
+    var child = master.getChild(0);
     expect(cache._cache['0' + master.xprivkey + '/0/false'].xprivkey).to.equal(child.xprivkey);
   });
   it('starts erasing unused keys', function() {
-    var child1 = master.derive(0);
-    var child2 = child1.derive(0);
-    var child3 = child2.derive(0);
+    var child1 = master.getChild(0);
+    var child2 = child1.getChild(0);
+    var child3 = child2.getChild(0);
     expect(cache._cache['0' + master.xprivkey + '/0/false'].xprivkey).to.equal(child1.xprivkey);
-    var child4 = child3.derive(0);
+    var child4 = child3.getChild(0);
     expect(cache._cache['0' + master.xprivkey + '/0/false']).to.equal(undefined);
   });
   it('avoids erasing keys that get cache hits ("hot keys")', function() {
-    var child1 = master.derive(0);
-    var child2 = master.derive(0).derive(0);
+    var child1 = master.getChild(0);
+    var child2 = master.getChild(0).getChild(0);
     expect(cache._cache['0' + master.xprivkey + '/0/false'].xprivkey).to.equal(child1.xprivkey);
-    var child1_copy = master.derive(0);
+    var child1_copy = master.getChild(0);
     expect(cache._cache['0' + master.xprivkey + '/0/false'].xprivkey).to.equal(child1.xprivkey);
   });
   it('keeps the size of the cache small', function() {
-    var child1 = master.derive(0);
-    var child2 = child1.derive(0);
-    var child3 = child2.derive(0);
-    var child4 = child3.derive(0);
+    var child1 = master.getChild(0);
+    var child2 = child1.getChild(0);
+    var child3 = child2.getChild(0);
+    var child4 = child3.getChild(0);
     expect(_.size(cache._cache)).to.equal(3);
   });
 });

--- a/test/hdkeys.js
+++ b/test/hdkeys.js
@@ -288,6 +288,27 @@ describe('BIP32 compliance', function() {
       derived.privateKey.toString().should.equal('b15bce3608d607ee3a49069197732c656bca942ee59f3e29b4d56914c1de6825');
       bitcore.PrivateKey.isValid.callCount.should.equal(2);
     });
+    it('will handle edge case that a derive public key is invalid', function() {
+      var publicKeyBuffer = new Buffer('029e58b241790284ef56502667b15157b3fc58c567f044ddc35653860f9455d099', 'hex');
+      var chainCodeBuffer = new Buffer('39816057bba9d952fe87fe998b7fd4d690a1bb58c2ff69141469e4d1dffb4b91', 'hex');
+      var key = new HDPublicKey({
+        network: 'testnet',
+        depth: 0,
+        parentFingerPrint: 0,
+        childIndex: 0,
+        chainCode: chainCodeBuffer,
+        publicKey: publicKeyBuffer
+      });
+      var unstubbed = bitcore.PublicKey.fromPoint;
+      bitcore.PublicKey.fromPoint = function() {
+        bitcore.PublicKey.fromPoint = unstubbed;
+        throw new Error('Point cannot be equal to Infinity');
+      };
+      sandbox.spy(key, '_deriveWithNumber');
+      var derived = key.derive("m/44");
+      key._deriveWithNumber.callCount.should.equal(2);
+      key.publicKey.toString().should.equal('029e58b241790284ef56502667b15157b3fc58c567f044ddc35653860f9455d099');
+    });
   });
 
   describe('seed', function() {

--- a/test/hdkeys.js
+++ b/test/hdkeys.js
@@ -221,6 +221,38 @@ describe('BIP32 compliance', function() {
       .xpubkey.should.equal(vector2_m02147483647h12147483646h2_public);
   });
 
+  it('should use full 32 bytes for private key data that is hashed (as per bip32)', function() {
+    // https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
+    var privateKeyBuffer = new Buffer('00000055378cf5fafb56c711c674143f9b0ee82ab0ba2924f19b64f5ae7cdbfd', 'hex');
+    var chainCodeBuffer = new Buffer('9c8a5c863e5941f3d99453e6ba66b328bb17cf0b8dec89ed4fc5ace397a1c089', 'hex');
+    var key = HDPrivateKey.fromObject({
+      network: 'testnet',
+      depth: 0,
+      parentFingerPrint: 0,
+      childIndex: 0,
+      privateKey: privateKeyBuffer,
+      chainCode: chainCodeBuffer
+    });
+    var derived = key.derive("m/44'/0'/0'/0/0'");
+    derived.privateKey.toString().should.equal('3348069561d2a0fb925e74bf198762acc47dce7db27372257d2d959a9e6f8aeb');
+  });
+
+  it('should NOT use full 32 bytes for private key data that is hashed with nonCompliant flag', function() {
+    // This is to test that the previously implemented non-compliant to BIP32
+    var privateKeyBuffer = new Buffer('00000055378cf5fafb56c711c674143f9b0ee82ab0ba2924f19b64f5ae7cdbfd', 'hex');
+    var chainCodeBuffer = new Buffer('9c8a5c863e5941f3d99453e6ba66b328bb17cf0b8dec89ed4fc5ace397a1c089', 'hex');
+    var key = HDPrivateKey.fromObject({
+      network: 'testnet',
+      depth: 0,
+      parentFingerPrint: 0,
+      childIndex: 0,
+      privateKey: privateKeyBuffer,
+      chainCode: chainCodeBuffer
+    });
+    var derived = key.deriveNonCompliant("m/44'/0'/0'/0/0'");
+    derived.privateKey.toString().should.equal('4811a079bab267bfdca855b3bddff20231ff7044e648514fa099158472df2836');
+  });
+
   describe('seed', function() {
 
     it('should initialize a new BIP32 correctly from test vector 1 seed', function() {

--- a/test/hdkeys.js
+++ b/test/hdkeys.js
@@ -81,69 +81,69 @@ describe('BIP32 compliance', function() {
   });
 
   it("should get m/0' ext. private key from test vector 1", function() {
-    var privateKey = new HDPrivateKey(vector1_m_private).derive("m/0'");
+    var privateKey = new HDPrivateKey(vector1_m_private).getChild("m/0'");
     privateKey.xprivkey.should.equal(vector1_m0h_private);
   });
 
   it("should get m/0' ext. public key from test vector 1", function() {
-    HDPrivateKey(vector1_m_private).derive("m/0'")
+    HDPrivateKey(vector1_m_private).getChild("m/0'")
       .xpubkey.should.equal(vector1_m0h_public);
   });
 
   it("should get m/0'/1 ext. private key from test vector 1", function() {
-    HDPrivateKey(vector1_m_private).derive("m/0'/1")
+    HDPrivateKey(vector1_m_private).getChild("m/0'/1")
       .xprivkey.should.equal(vector1_m0h1_private);
   });
 
   it("should get m/0'/1 ext. public key from test vector 1", function() {
-    HDPrivateKey(vector1_m_private).derive("m/0'/1")
+    HDPrivateKey(vector1_m_private).getChild("m/0'/1")
       .xpubkey.should.equal(vector1_m0h1_public);
   });
 
   it("should get m/0'/1 ext. public key from m/0' public key from test vector 1", function() {
-    var derivedPublic = HDPrivateKey(vector1_m_private).derive("m/0'").hdPublicKey.derive("m/1");
+    var derivedPublic = HDPrivateKey(vector1_m_private).getChild("m/0'").hdPublicKey.getChild("m/1");
     derivedPublic.xpubkey.should.equal(vector1_m0h1_public);
   });
 
   it("should get m/0'/1/2' ext. private key from test vector 1", function() {
     var privateKey = new HDPrivateKey(vector1_m_private);
-    var derived = privateKey.derive("m/0'/1/2'");
+    var derived = privateKey.getChild("m/0'/1/2'");
     derived.xprivkey.should.equal(vector1_m0h12h_private);
   });
 
   it("should get m/0'/1/2' ext. public key from test vector 1", function() {
-    HDPrivateKey(vector1_m_private).derive("m/0'/1/2'")
+    HDPrivateKey(vector1_m_private).getChild("m/0'/1/2'")
       .xpubkey.should.equal(vector1_m0h12h_public);
   });
 
   it("should get m/0'/1/2'/2 ext. private key from test vector 1", function() {
-    HDPrivateKey(vector1_m_private).derive("m/0'/1/2'/2")
+    HDPrivateKey(vector1_m_private).getChild("m/0'/1/2'/2")
       .xprivkey.should.equal(vector1_m0h12h2_private);
   });
 
   it("should get m/0'/1/2'/2 ext. public key from m/0'/1/2' public key from test vector 1", function() {
-    var derived = HDPrivateKey(vector1_m_private).derive("m/0'/1/2'").hdPublicKey;
-    derived.derive("m/2").xpubkey.should.equal(vector1_m0h12h2_public);
+    var derived = HDPrivateKey(vector1_m_private).getChild("m/0'/1/2'").hdPublicKey;
+    derived.getChild("m/2").xpubkey.should.equal(vector1_m0h12h2_public);
   });
 
   it("should get m/0'/1/2h/2 ext. public key from test vector 1", function() {
-    HDPrivateKey(vector1_m_private).derive("m/0'/1/2'/2")
+    HDPrivateKey(vector1_m_private).getChild("m/0'/1/2'/2")
       .xpubkey.should.equal(vector1_m0h12h2_public);
   });
 
   it("should get m/0'/1/2h/2/1000000000 ext. private key from test vector 1", function() {
-    HDPrivateKey(vector1_m_private).derive("m/0'/1/2'/2/1000000000")
+    HDPrivateKey(vector1_m_private).getChild("m/0'/1/2'/2/1000000000")
       .xprivkey.should.equal(vector1_m0h12h21000000000_private);
   });
 
   it("should get m/0'/1/2h/2/1000000000 ext. public key from test vector 1", function() {
-    HDPrivateKey(vector1_m_private).derive("m/0'/1/2'/2/1000000000")
+    HDPrivateKey(vector1_m_private).getChild("m/0'/1/2'/2/1000000000")
       .xpubkey.should.equal(vector1_m0h12h21000000000_public);
   });
 
   it("should get m/0'/1/2'/2/1000000000 ext. public key from m/0'/1/2'/2 public key from test vector 1", function() {
-    var derived = HDPrivateKey(vector1_m_private).derive("m/0'/1/2'/2").hdPublicKey;
-    derived.derive("m/1000000000").xpubkey.should.equal(vector1_m0h12h21000000000_public);
+    var derived = HDPrivateKey(vector1_m_private).getChild("m/0'/1/2'/2").hdPublicKey;
+    derived.getChild("m/1000000000").xpubkey.should.equal(vector1_m0h12h21000000000_public);
   });
 
   it('should initialize test vector 2 from the extended public key', function() {
@@ -159,66 +159,66 @@ describe('BIP32 compliance', function() {
   });
 
   it("should get m/0 ext. private key from test vector 2", function() {
-    HDPrivateKey(vector2_m_private).derive(0).xprivkey.should.equal(vector2_m0_private);
+    HDPrivateKey(vector2_m_private).getChild(0).xprivkey.should.equal(vector2_m0_private);
   });
 
   it("should get m/0 ext. public key from test vector 2", function() {
-    HDPrivateKey(vector2_m_private).derive(0).xpubkey.should.equal(vector2_m0_public);
+    HDPrivateKey(vector2_m_private).getChild(0).xpubkey.should.equal(vector2_m0_public);
   });
 
   it("should get m/0 ext. public key from m public key from test vector 2", function() {
-    HDPrivateKey(vector2_m_private).hdPublicKey.derive(0).xpubkey.should.equal(vector2_m0_public);
+    HDPrivateKey(vector2_m_private).hdPublicKey.getChild(0).xpubkey.should.equal(vector2_m0_public);
   });
 
   it("should get m/0/2147483647h ext. private key from test vector 2", function() {
-    HDPrivateKey(vector2_m_private).derive("m/0/2147483647'")
+    HDPrivateKey(vector2_m_private).getChild("m/0/2147483647'")
       .xprivkey.should.equal(vector2_m02147483647h_private);
   });
 
   it("should get m/0/2147483647h ext. public key from test vector 2", function() {
-    HDPrivateKey(vector2_m_private).derive("m/0/2147483647'")
+    HDPrivateKey(vector2_m_private).getChild("m/0/2147483647'")
       .xpubkey.should.equal(vector2_m02147483647h_public);
   });
 
   it("should get m/0/2147483647h/1 ext. private key from test vector 2", function() {
-    HDPrivateKey(vector2_m_private).derive("m/0/2147483647'/1")
+    HDPrivateKey(vector2_m_private).getChild("m/0/2147483647'/1")
       .xprivkey.should.equal(vector2_m02147483647h1_private);
   });
 
   it("should get m/0/2147483647h/1 ext. public key from test vector 2", function() {
-    HDPrivateKey(vector2_m_private).derive("m/0/2147483647'/1")
+    HDPrivateKey(vector2_m_private).getChild("m/0/2147483647'/1")
       .xpubkey.should.equal(vector2_m02147483647h1_public);
   });
 
   it("should get m/0/2147483647h/1 ext. public key from m/0/2147483647h public key from test vector 2", function() {
-    var derived = HDPrivateKey(vector2_m_private).derive("m/0/2147483647'").hdPublicKey;
-    derived.derive(1).xpubkey.should.equal(vector2_m02147483647h1_public);
+    var derived = HDPrivateKey(vector2_m_private).getChild("m/0/2147483647'").hdPublicKey;
+    derived.getChild(1).xpubkey.should.equal(vector2_m02147483647h1_public);
   });
 
   it("should get m/0/2147483647h/1/2147483646h ext. private key from test vector 2", function() {
-    HDPrivateKey(vector2_m_private).derive("m/0/2147483647'/1/2147483646'")
+    HDPrivateKey(vector2_m_private).getChild("m/0/2147483647'/1/2147483646'")
       .xprivkey.should.equal(vector2_m02147483647h12147483646h_private);
   });
 
   it("should get m/0/2147483647h/1/2147483646h ext. public key from test vector 2", function() {
-    HDPrivateKey(vector2_m_private).derive("m/0/2147483647'/1/2147483646'")
+    HDPrivateKey(vector2_m_private).getChild("m/0/2147483647'/1/2147483646'")
       .xpubkey.should.equal(vector2_m02147483647h12147483646h_public);
   });
 
   it("should get m/0/2147483647h/1/2147483646h/2 ext. private key from test vector 2", function() {
-    HDPrivateKey(vector2_m_private).derive("m/0/2147483647'/1/2147483646'/2")
+    HDPrivateKey(vector2_m_private).getChild("m/0/2147483647'/1/2147483646'/2")
       .xprivkey.should.equal(vector2_m02147483647h12147483646h2_private);
   });
 
   it("should get m/0/2147483647h/1/2147483646h/2 ext. public key from test vector 2", function() {
-    HDPrivateKey(vector2_m_private).derive("m/0/2147483647'/1/2147483646'/2")
+    HDPrivateKey(vector2_m_private).getChild("m/0/2147483647'/1/2147483646'/2")
       .xpubkey.should.equal(vector2_m02147483647h12147483646h2_public);
   });
 
   it("should get m/0/2147483647h/1/2147483646h/2 ext. public key from m/0/2147483647h/2147483646h public key from test vector 2", function() {
     var derivedPublic = HDPrivateKey(vector2_m_private)
-      .derive("m/0/2147483647'/1/2147483646'").hdPublicKey;
-    derivedPublic.derive("m/2")
+      .getChild("m/0/2147483647'/1/2147483646'").hdPublicKey;
+    derivedPublic.getChild("m/2")
       .xpubkey.should.equal(vector2_m02147483647h12147483646h2_public);
   });
 
@@ -234,7 +234,7 @@ describe('BIP32 compliance', function() {
       privateKey: privateKeyBuffer,
       chainCode: chainCodeBuffer
     });
-    var derived = key.derive("m/44'/0'/0'/0/0'");
+    var derived = key.getChild("m/44'/0'/0'/0/0'");
     derived.privateKey.toString().should.equal('3348069561d2a0fb925e74bf198762acc47dce7db27372257d2d959a9e6f8aeb');
   });
 
@@ -250,7 +250,7 @@ describe('BIP32 compliance', function() {
       privateKey: privateKeyBuffer,
       chainCode: chainCodeBuffer
     });
-    var derived = key.deriveNonCompliant("m/44'/0'/0'/0/0'");
+    var derived = key.getNonCompliantChild("m/44'/0'/0'/0/0'");
     derived.privateKey.toString().should.equal('4811a079bab267bfdca855b3bddff20231ff7044e648514fa099158472df2836');
   });
 
@@ -284,11 +284,11 @@ describe('BIP32 compliance', function() {
         privateKey: privateKeyBuffer,
         chainCode: chainCodeBuffer
       });
-      var derived = key.derive("m/44'");
+      var derived = key.getChild("m/44'");
       derived.privateKey.toString().should.equal('b15bce3608d607ee3a49069197732c656bca942ee59f3e29b4d56914c1de6825');
       bitcore.PrivateKey.isValid.callCount.should.equal(2);
     });
-    it('will handle edge case that a derive public key is invalid', function() {
+    it('will handle edge case that a getChild public key is invalid', function() {
       var publicKeyBuffer = new Buffer('029e58b241790284ef56502667b15157b3fc58c567f044ddc35653860f9455d099', 'hex');
       var chainCodeBuffer = new Buffer('39816057bba9d952fe87fe998b7fd4d690a1bb58c2ff69141469e4d1dffb4b91', 'hex');
       var key = new HDPublicKey({
@@ -305,7 +305,7 @@ describe('BIP32 compliance', function() {
         throw new Error('Point cannot be equal to Infinity');
       };
       sandbox.spy(key, '_deriveWithNumber');
-      var derived = key.derive("m/44");
+      var derived = key.getChild("m/44");
       key._deriveWithNumber.callCount.should.equal(2);
       key.publicKey.toString().should.equal('029e58b241790284ef56502667b15157b3fc58c567f044ddc35653860f9455d099');
     });

--- a/test/hdpublickey.js
+++ b/test/hdpublickey.js
@@ -32,7 +32,7 @@ describe('HDPublicKey interface', function() {
   var expectDerivationFail = function(argument, error) {
     (function() {
       var pubkey = new HDPublicKey(xpubkey);
-      pubkey.derive(argument);
+      pubkey.getChild(argument);
     }).should.throw(error);
   };
 
@@ -188,15 +188,15 @@ describe('HDPublicKey interface', function() {
   describe('derivation', function() {
     it('derivation is the same whether deriving with number or string', function() {
       var pubkey = new HDPublicKey(xpubkey);
-      var derived1 = pubkey.derive(0).derive(1).derive(200000);
-      var derived2 = pubkey.derive('m/0/1/200000');
+      var derived1 = pubkey.getChild(0).getChild(1).getChild(200000);
+      var derived2 = pubkey.getChild('m/0/1/200000');
       derived1.xpubkey.should.equal(derived_0_1_200000);
       derived2.xpubkey.should.equal(derived_0_1_200000);
     });
 
     it('allows special parameters m, M', function() {
       var expectDerivationSuccess = function(argument) {
-        new HDPublicKey(xpubkey).derive(argument).xpubkey.should.equal(xpubkey);
+        new HDPublicKey(xpubkey).getChild(argument).xpubkey.should.equal(xpubkey);
       };
       expectDerivationSuccess('m');
       expectDerivationSuccess('M');
@@ -204,13 +204,13 @@ describe('HDPublicKey interface', function() {
 
     it('doesn\'t allow object arguments for derivation', function() {
       expectFail(function() {
-        return new HDPublicKey(xpubkey).derive({});
+        return new HDPublicKey(xpubkey).getChild({});
       }, hdErrors.InvalidDerivationArgument);
     });
 
     it('needs first argument for derivation', function() {
       expectFail(function() {
-        return new HDPublicKey(xpubkey).derive('s');
+        return new HDPublicKey(xpubkey).getChild('s');
       }, hdErrors.InvalidPath);
     });
 
@@ -224,13 +224,13 @@ describe('HDPublicKey interface', function() {
 
     it('can\'t derive hardened keys', function() {
       expectFail(function() {
-        return new HDPublicKey(xpubkey).derive(HDPublicKey.Hardened);
+        return new HDPublicKey(xpubkey).getChild(HDPublicKey.Hardened);
       }, hdErrors.InvalidIndexCantDeriveHardened);
     });
 
     it('can\'t derive hardened keys via second argument', function() {
       expectFail(function() {
-        return new HDPublicKey(xpubkey).derive(5, true);
+        return new HDPublicKey(xpubkey).getChild(5, true);
       }, hdErrors.InvalidIndexCantDeriveHardened);
     });
 
@@ -274,8 +274,8 @@ describe('HDPublicKey interface', function() {
 
     it('should use the cache', function() {
       var pubkey = new HDPublicKey(xpubkey);
-      var derived1 = pubkey.derive(0);
-      var derived2 = pubkey.derive(0);
+      var derived1 = pubkey.getChild(0);
+      var derived2 = pubkey.getChild(0);
       derived1.should.equal(derived2);
     });
   });

--- a/test/privatekey.js
+++ b/test/privatekey.js
@@ -331,6 +331,20 @@ describe('PrivateKey', function() {
       fromBuffer.toString().should.equal(privkey.toString());
     });
 
+    it('will output a 32 byte buffer', function() {
+      var bn = BN.fromBuffer(new Buffer('9b5a0e8fee1835e21170ce1431f9b6f19b487e67748ed70d8a4462bc031915', 'hex'));
+      var privkey = new PrivateKey(bn);
+      var buffer = privkey.toBuffer();
+      buffer.length.should.equal(32);
+    });
+
+    it('will output a 31 byte buffer', function() {
+      var bn = BN.fromBuffer(new Buffer('9b5a0e8fee1835e21170ce1431f9b6f19b487e67748ed70d8a4462bc031915', 'hex'));
+      var privkey = new PrivateKey(bn);
+      var buffer = privkey.toBufferNoPadding();
+      buffer.length.should.equal(31);
+    });
+
     it('should return buffer with length equal 32', function() {
       var bn = BN.fromBuffer(buf.slice(0, 31));
       var privkey = new PrivateKey(bn, 'livenet');

--- a/test/privatekey.js
+++ b/test/privatekey.js
@@ -330,6 +330,13 @@ describe('PrivateKey', function() {
       var fromBuffer = PrivateKey.fromBuffer(toBuffer.toBuffer());
       fromBuffer.toString().should.equal(privkey.toString());
     });
+
+    it('should return buffer with length equal 32', function() {
+      var bn = BN.fromBuffer(buf.slice(0, 31));
+      var privkey = new PrivateKey(bn, 'livenet');
+      var expected = Buffer.concat([ new Buffer([0]), buf.slice(0, 31) ]);
+      privkey.toBuffer().toString('hex').should.equal(expected.toString('hex'));
+    });
   });
 
   describe('#toBigNumber', function() {


### PR DESCRIPTION
This is an alternative to https://github.com/bitpay/bitcore-lib/pull/97, aim to keep backwards compatibility by default, so bitcore users that upgrade the library without knowing the details of the key derivation changes, wont be on risk of loosing access to private keys.