### PR TITLE
Directly use Buffer.isBuffer (Cordova, RN workaround)

### DIFF
--- a/lib/util/preconditions.js
+++ b/lib/util/preconditions.js
@@ -18,8 +18,8 @@ module.exports = {
     argumentName = argumentName || '(unknown name)';
     if (_.isString(type)) {
       if (type === 'Buffer') {
-        var BufferUtil = require('./buffer');
-        if (!BufferUtil.isBuffer(argument)) {
+        var buffer = require('buffer'); // './buffer' fails on cordova & RN
+        if (!buffer.Buffer.isBuffer(argument)) {
           throw new errors.InvalidArgumentType(argument, type, argumentName);
         }
       } else if (typeof argument !== type) {


### PR DESCRIPTION

Using "./buffer" fails on some browserify-esque platforms
such as Cordova and React.Native.

Fixes #108