### PR TITLE
calculate a more accurate fee based without rounding to the nearest kB

### DIFF
--- a/lib/transaction/transaction.js
+++ b/lib/transaction/transaction.js
@@ -910,11 +910,11 @@ Transaction.prototype._clearSignatures = function() {
 };
 
 Transaction._estimateFee = function(size, amountAvailable, feePerKb) {
-  var fee = Math.ceil(size / 1000) * (feePerKb || Transaction.FEE_PER_KB);
+  var fee = Math.ceil(size / 1000 * (feePerKb || Transaction.FEE_PER_KB));
   if (amountAvailable > fee) {
     size += Transaction.CHANGE_OUTPUT_MAX_SIZE;
   }
-  return Math.ceil(size / 1000) * (feePerKb || Transaction.FEE_PER_KB);
+  return Math.ceil(size / 1000 * (feePerKb || Transaction.FEE_PER_KB));
 };
 
 Transaction.prototype._estimateSize = function() {


### PR DESCRIPTION
this is related to #101.  As mentioned, bitcoin-core has stopped rounding to the nearest kB starting from 0.12.  This pull requests brings bitcore-lib up to date with that.