### PR TITLE
Fixed issue: ripemd160 is not supported (we accept pull requests)

### DIFF
--- a/lib/crypto/hash.js
+++ b/lib/crypto/hash.js
@@ -27,7 +27,7 @@ Hash.sha256sha256 = function(buf) {
 
 Hash.ripemd160 = function(buf) {
   $.checkArgument(BufferUtil.isBuffer(buf));
-  return crypto.createHash('ripemd160').update(buf).digest();
+  return crypto.createHash('rmd160').update(buf).digest();
 };
 
 Hash.sha256ripemd160 = function(buf) {

--- a/lib/privatekey.js
+++ b/lib/privatekey.js
@@ -336,8 +336,7 @@ PrivateKey.prototype.toBigNumber = function(){
  * @returns {Buffer} A buffer of the private key
  */
 PrivateKey.prototype.toBuffer = function(){
-  // TODO: use `return this.bn.toBuffer({ size: 32 })` in v1.0.0
-  return this.bn.toBuffer();
+  return this.bn.toBuffer({ size: 32 });
 };
 
 /**


### PR DESCRIPTION
Fixed issue: ripemd160 is not supported (we accept pull requests).
This issue was caused for me when using eth-lightwallet. Due to the refactoring of ripemd160 to rmd160, this error occurred.