### PR TITLE
Updating cash network magic to match ABC

### DIFF
--- a/lib/networks.js
+++ b/lib/networks.js
@@ -208,7 +208,7 @@ for (var key in TESTNET) {
 
 var REGTEST = {
   PORT: 18444,
-  NETWORK_MAGIC: BufferUtil.integerAsBuffer(0xfabfb5da),
+  NETWORK_MAGIC: BufferUtil.integerAsBuffer(0xdab5bffa),
   DNS_SEEDS: []
 };
 

--- a/lib/networks.js
+++ b/lib/networks.js
@@ -153,7 +153,7 @@ addNetwork({
   scripthash: 40,
   xpubkey: 0x0488b21e,
   xprivkey: 0x0488ade4,
-  networkMagic: 0xf9beb4d9,
+  networkMagic: 0xe3e1f3e8,
   port: 8333,
   dnsSeeds: [
     'seed.bitcoinabc.org',
@@ -190,7 +190,7 @@ var testnet = get('testnet');
 
 var TESTNET = {
   PORT: 18333,
-  NETWORK_MAGIC: BufferUtil.integerAsBuffer(0x0b110907),
+  NETWORK_MAGIC: BufferUtil.integerAsBuffer(0xf4e5f3f4),
   DNS_SEEDS: [
     'seed.bitcoinabc.org',
     'seed-abc.bitcoinforks.org',


### PR DESCRIPTION
Closes https://github.com/bitpay/bitcore-lib/issues/193

Checked peer connections, and all of the networkMagic numbers in bitcore-lib/cash were referencing the diskMagic numbers. 

This is breaking p2p for Bitcoin ABC version v0.16.2.0, this PR should fix p2p.
