### PR TITLE
Regtest Support

### DIFF
--- a/lib/networks.js
+++ b/lib/networks.js
@@ -216,7 +216,7 @@ var regtest = get('regtest');
 var REGTEST = {
   PORT: 18444,
   NETWORK_MAGIC: BufferUtil.integerAsBuffer(networkMagic.regtest),
-  DNS_SEEDS: dnsSeeds
+  DNS_SEEDS: []
 };
 
 for (var key in REGTEST) {

--- a/lib/networks.js
+++ b/lib/networks.js
@@ -39,7 +39,7 @@ function get(arg, keys) {
     };
     for (var index in networks) {
       if (_.some(keys, containsArg)) {
-        return networks[index];
+	return networks[index];
       }
     }
     return undefined;
@@ -51,7 +51,7 @@ function get(arg, keys) {
  * Derives an array from the given prefix to be used in the computation
  * of the address' checksum.
  *
- * @param {string} prefix Network prefix. E.g.: 'bitcoincash'. 
+ * @param {string} prefix Network prefix. E.g.: 'bitcoincash'.
  */
 function prefixToArray(prefix) {
   var result = [];
@@ -144,6 +144,20 @@ function removeNetwork(network) {
   }
 }
 
+var networkMagic = {
+  livenet: 0xe3e1f3e8,
+  testnet: 0xf4e5f3f4,
+  regtest: 0xdab5bffa,
+};
+
+var dnsSeeds = [
+  'seed.bitcoinabc.org',
+  'seed-abc.bitcoinforks.org',
+  'seed.bitcoinunlimited.info',
+  'seed.bitprim.org ',
+  'seed.deadalnix.me'
+];
+
 addNetwork({
   name: 'livenet',
   alias: 'mainnet',
@@ -153,15 +167,9 @@ addNetwork({
   scripthash: 40,
   xpubkey: 0x0488b21e,
   xprivkey: 0x0488ade4,
-  networkMagic: 0xe3e1f3e8,
+  networkMagic: networkMagic.livenet,
   port: 8333,
-  dnsSeeds: [
-    'seed.bitcoinabc.org',
-    'seed-abc.bitcoinforks.org',
-    'seed.bitcoinunlimited.info',
-    'seed.bitprim.org ',
-    'seed.deadalnix.me'
-  ]
+  dnsSeeds: dnsSeeds
 });
 
 /**
@@ -170,6 +178,8 @@ addNetwork({
  */
 var livenet = get('livenet');
 
+// network magic, port, and dnsSeeds are overloaded by enableRegtest
+
 addNetwork({
   name: 'testnet',
   prefix: 'bchtest',
@@ -177,7 +187,7 @@ addNetwork({
   privatekey: 0xef,
   scripthash: 0xc4,
   xpubkey: 0x043587cf,
-  xprivkey: 0x04358394
+  xprivkey: 0x04358394,
 });
 
 /**
@@ -190,14 +200,8 @@ var testnet = get('testnet');
 
 var TESTNET = {
   PORT: 18333,
-  NETWORK_MAGIC: BufferUtil.integerAsBuffer(0xf4e5f3f4),
-  DNS_SEEDS: [
-    'seed.bitcoinabc.org',
-    'seed-abc.bitcoinforks.org',
-    'seed.bitcoinunlimited.info',
-    'seed.bitprim.org ',
-    'seed.deadalnix.me',
-  ]
+  NETWORK_MAGIC: BufferUtil.integerAsBuffer(networkMagic.testnet),
+  DNS_SEEDS: dnsSeeds
 };
 
 for (var key in TESTNET) {
@@ -206,10 +210,25 @@ for (var key in TESTNET) {
   }
 }
 
+addNetwork({
+  name: 'regtest',
+  prefix: 'bchtest',
+  pubkeyhash: 0x6f,
+  privatekey: 0xef,
+  scripthash: 0xc4,
+  xpubkey: 0x043587cf,
+  xprivkey: 0x04358394,
+  networkMagic: networkMagic.regtest,
+  port: 18444,
+  dnsSeeds: dnsSeeds
+});
+
+var regtest = get('regtest');
+
 var REGTEST = {
   PORT: 18444,
-  NETWORK_MAGIC: BufferUtil.integerAsBuffer(0xdab5bffa),
-  DNS_SEEDS: []
+  NETWORK_MAGIC: BufferUtil.integerAsBuffer(networkMagic.regtest),
+  DNS_SEEDS: dnsSeeds
 };
 
 for (var key in REGTEST) {
@@ -282,6 +301,7 @@ module.exports = {
   livenet: livenet,
   mainnet: livenet,
   testnet: testnet,
+  regtest: regtest,
   get: get,
   enableRegtest: enableRegtest,
   disableRegtest: disableRegtest

--- a/lib/networks.js
+++ b/lib/networks.js
@@ -182,6 +182,7 @@ var livenet = get('livenet');
 
 addNetwork({
   name: 'testnet',
+  alias: 'regtest',
   prefix: 'bchtest',
   pubkeyhash: 0x6f,
   privatekey: 0xef,
@@ -210,19 +211,6 @@ for (var key in TESTNET) {
   }
 }
 
-addNetwork({
-  name: 'regtest',
-  prefix: 'bchtest',
-  pubkeyhash: 0x6f,
-  privatekey: 0xef,
-  scripthash: 0xc4,
-  xpubkey: 0x043587cf,
-  xprivkey: 0x04358394,
-  networkMagic: networkMagic.regtest,
-  port: 18444,
-  dnsSeeds: dnsSeeds
-});
-
 var regtest = get('regtest');
 
 var REGTEST = {
@@ -233,7 +221,7 @@ var REGTEST = {
 
 for (var key in REGTEST) {
   if (!_.isObject(REGTEST[key])) {
-    networkMaps[REGTEST[key]] = testnet;
+    networkMaps[REGTEST[key]] = regtest;
   }
 }
 

--- a/test/networks.js
+++ b/test/networks.js
@@ -92,6 +92,10 @@ describe('Networks', function() {
     expect(networks.get(0x6f, ['privatekey', 'port'])).to.equal(undefined);
   });
 
+  it('should have regtest network', function() {
+    expect(networks.get('regtest').name).to.equal('testnet');
+  });
+
   it('converts to string using the "name" property', function() {
     networks.livenet.toString().should.equal('livenet');
   });


### PR DESCRIPTION
# Goals
* We need access to 'regtest' as a network
* dns and magic numbers from a single variable 
* stays backward compatible with testnet becoming regtest from enableRegtest