### PR TITLE
Fix/isvalid prefix

### DIFF
--- a/lib/address.js
+++ b/lib/address.js
@@ -75,12 +75,10 @@ function Address(data, network, type) {
   }
 
   var info = this._classifyArguments(data, network, type);
-  
 
   // set defaults if not set
   info.network = info.network || Networks.get(network) || Networks.defaultNetwork;
   info.type = info.type || type || Address.PayToPublicKeyHash;
-
 
   JSUtil.defineImmutable(this, {
     hashBuffer: info.hashBuffer,

--- a/lib/address.js
+++ b/lib/address.js
@@ -217,7 +217,7 @@ Address._transformBuffer = function(buffer, network, type) {
   }
 
   info.hashBuffer = buffer.slice(1);
-  info.network = bufferVersion.network ;
+  info.network = bufferVersion.network;
   info.type = bufferVersion.type;
   return info;
 };
@@ -320,7 +320,7 @@ function decodeCashAddress(address) {
   } else {
 
     var netNames = ['livenet','testnet'];
-    var i; 
+    var i;
 
     while(!prefix && (i = netNames.shift())){
       var p  =  Networks.get(i).prefix;
@@ -382,6 +382,7 @@ Address._transformString = function(data, network, type) {
   data = data.trim();
   var addressBuffer;
   var networkObj = Networks.get(network);
+  var info;
 
   try {
     addressBuffer = Base58Check.decode(data);
@@ -394,7 +395,7 @@ Address._transformString = function(data, network, type) {
   }
 
   // Legacy addr
-  var info = Address._transformBuffer(addressBuffer, network, type);
+  info = Address._transformBuffer(addressBuffer, network, type);
   return info;
 };
 

--- a/test/address.js
+++ b/test/address.js
@@ -202,7 +202,17 @@ describe('Address', function() {
       var valid = Address.isValid('HC1hAdrx7APHg1DkE4bVLsZhY1SE5Dik1r', 'testnet');
       valid.should.equal(false);
     });
+
+    it('isValid returns false on network mismatch on cashaddr', function() {
+      var valid = Address.isValid('bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a', 'regtest');
+      valid.should.equal(false);
+    });
     
+    it('isValid returns true on network match on cashaddr', function() {
+      var valid = Address.isValid('bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a', 'mainnet');
+      valid.should.equal(true);
+    });
+
     it('validates correctly the P2PKH test vector', function() {
       for (var i = 0; i < PKHLivenet.length; i++) {
         var error = Address.getValidationError(PKHLivenet[i]);

--- a/test/address.js
+++ b/test/address.js
@@ -67,74 +67,74 @@ describe('Address', function() {
     });
   });
 
-  describe('Cashaddr', function(){
+  describe('Cashaddr', function() {
 
     //from https://github.com/Bitcoin-UAHF/spec/blob/master/cashaddr.md#examples-of-address-translation
     //
     //
     var t = [
-      ['CTH8H8Zj6DSnXFBKQeDG28ogAS92iS16Bp','bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a'],
-      ['Cazk5ZxnJGY1iYqqTefvo7ZtwLYx3YzjgY','bitcoincash:qr95sy3j9xwd2ap32xkykttr4cvcu7as4y0qverfuy'],
-      ['CGZpaFRaJYHqohPJ8BKYvKmxffV2dcmmN9','bitcoincash:qqq3728yw0y47sqn6l2na30mcw6zm78dzqre909m2r'],
-      ['HHLN6S9BcP1JLSrMhgD5qe57iVEMFMLCBT','bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq'],
-      ['HR3ytsYEpS6XXkWskgfkccqLVPeGdXQ1S8','bitcoincash:pr95sy3j9xwd2ap32xkykttr4cvcu7as4yc93ky28e'],
-      ['H6d4PZ12phrMcu4LRDKNjq3QDiaMDz3fUd','bitcoincash:pqq3728yw0y47sqn6l2na30mcw6zm78dzq5ucqzc37'],
+      ['CTH8H8Zj6DSnXFBKQeDG28ogAS92iS16Bp', 'bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a'],
+      ['Cazk5ZxnJGY1iYqqTefvo7ZtwLYx3YzjgY', 'bitcoincash:qr95sy3j9xwd2ap32xkykttr4cvcu7as4y0qverfuy'],
+      ['CGZpaFRaJYHqohPJ8BKYvKmxffV2dcmmN9', 'bitcoincash:qqq3728yw0y47sqn6l2na30mcw6zm78dzqre909m2r'],
+      ['HHLN6S9BcP1JLSrMhgD5qe57iVEMFMLCBT', 'bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq'],
+      ['HR3ytsYEpS6XXkWskgfkccqLVPeGdXQ1S8', 'bitcoincash:pr95sy3j9xwd2ap32xkykttr4cvcu7as4yc93ky28e'],
+      ['H6d4PZ12phrMcu4LRDKNjq3QDiaMDz3fUd', 'bitcoincash:pqq3728yw0y47sqn6l2na30mcw6zm78dzq5ucqzc37'],
     ];
     var i;
- 
-    for(i=0; i<t.length; i++) {
+
+    for (i = 0; i < t.length; i++) {
       var legacyaddr = t[i][0];
       var cashaddr = t[i][1];
-      it('should convert ' + legacyaddr, function() { 
+      it('should convert ' + legacyaddr, function() {
         var a = new Address(legacyaddr);
         a.toCashAddress().should.equal(cashaddr);
       });
-    }   
+    }
 
- 
-    for(i=0; i<t.length; i++) {
+
+    for (i = 0; i < t.length; i++) {
       var legacyaddr = t[i][0];
       var cashaddr = t[i][1];
-      it('should convert ' + cashaddr, function() { 
+      it('should convert ' + cashaddr, function() {
         var a = new Address(cashaddr);
         a.toString().should.equal(legacyaddr);
       });
     }
 
-    for(i=0; i<t.length; i++) {
+    for (i = 0; i < t.length; i++) {
       var legacyaddr2 = t[i][0];
       var cashaddr2 = t[i][1].toUpperCase();
-      it('should convert UPPERCASE addresses ' + cashaddr2, function() { 
+      it('should convert UPPERCASE addresses ' + cashaddr2, function() {
         var a = new Address(cashaddr2);
         a.toString().should.equal(legacyaddr2);
-     });
-    } 
+      });
+    }
 
 
-    for(i=0; i<t.length; i++) {
+    for (i = 0; i < t.length; i++) {
       var legacyaddr3 = t[i][0];
       var cashaddr3 = t[i][1].split(':')[1];
-      it('should convert no prefix addresses ' + cashaddr3, function() { 
+      it('should convert no prefix addresses ' + cashaddr3, function() {
         var a = new Address(cashaddr3);
         a.toObject().network.should.equal('livenet');
         a.toString().should.equal(legacyaddr3);
-     });
-    } 
+      });
+    }
 
 
-    it('should fail convert no prefix addresses bad checksum ', function() { 
+    it('should fail convert no prefix addresses bad checksum ', function() {
       (function() {
-      var a = new Address('qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx7');
+        var a = new Address('qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx7');
       }).should.throw('Invalid checksum');
     });
 
-    it('should fail convert a mixed case addresses ', function() { 
+    it('should fail convert a mixed case addresses ', function() {
       (function() {
-      var a = new Address('qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6A');
+        var a = new Address('qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6A');
       }).should.throw('Invalid Argument: Mixed case');
     });
   });
- 
+
 
   // livenet valid
   var PKHLivenet = [
@@ -207,9 +207,19 @@ describe('Address', function() {
       var valid = Address.isValid('bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a', 'regtest');
       valid.should.equal(false);
     });
-    
+
     it('isValid returns true on network match on cashaddr', function() {
       var valid = Address.isValid('bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a', 'mainnet');
+      valid.should.equal(true);
+    });
+
+    it('isValid returns true on network match on cashaddr regtest', function() {
+      var valid = Address.isValid('bchreg:qrjf2q4j0vx7xwqlnzcuy56vk9j9an0z458k0lrw3m', 'regtest');
+      valid.should.equal(true);
+    });
+
+    it('isValid returns true on network match on cashaddr testnet', function() {
+      var valid = Address.isValid('bchtest:qrzm24wqva0gnvgcsyc0h8tdpgw462mgmc9lef83vw', 'testnet');
       valid.should.equal(true);
     });
 
@@ -257,7 +267,8 @@ describe('Address', function() {
     });
 
     it('should not validate on a network mismatch', function() {
-      var error, i;
+      var error,
+        i;
       for (i = 0; i < PKHLivenet.length; i++) {
         error = Address.getValidationError(PKHLivenet[i], 'testnet', 'pubkeyhash');
         should.exist(error);
@@ -331,7 +342,7 @@ describe('Address', function() {
     });
 
     it('should throw with bad network param', function() {
-      (function(){
+      (function() {
         Address.fromString(str, 'somenet');
       }).should.throw('Unknown network');
     });


### PR DESCRIPTION
The following was returning true on master

bitcoreCash.Address.isValid('bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a', 'regtest')

Now the network prefix is checked against the address.
Adding tests.
Fixing some spacing inconsistency.
