### PR TITLE
isValid() / toCashAddr() Testnet support

### DIFF
--- a/lib/address.js
+++ b/lib/address.js
@@ -317,7 +317,7 @@ function decodeCashAddress(address) {
     $.checkArgument(validChecksum(prefix, payload), 'Invalid checksum:'+ address);
   } else {
 
-    var netNames = ['livenet','testnet'];
+    var netNames = ['livenet','testnet','regtest'];
     var i;
 
     while(!prefix && (i = netNames.shift())){
@@ -386,7 +386,7 @@ Address._transformString = function(data, network, type) {
     addressBuffer = Base58Check.decode(data);
   } catch (e) {
     info = decodeCashAddress(data);
-    if (!info.network || (networkObj && networkObj !== info.network)) {
+    if (!info.network || (networkObj && networkObj.prefix !== info.network.prefix)) {
       throw new TypeError('Address has mismatched network type.');
     }
     return info;

--- a/lib/networks.js
+++ b/lib/networks.js
@@ -296,6 +296,18 @@ Object.defineProperty(testnet, 'prefix', {
   }
 });
 
+Object.defineProperty(testnet, 'prefixArray', {
+  enumerable: true,
+  configurable: false,
+  get: function() {
+    if (this.regtestEnabled) {
+      return prefixToArray(REGTEST.PREFIX);
+    } else {
+      return prefixToArray(TESTNET.PREFIX);
+    }
+  }
+});
+
 /**
  * @function
  * @member Networks#enableRegtest

--- a/test/address.js
+++ b/test/address.js
@@ -121,6 +121,10 @@ describe('Address', function() {
       });
     }
 
+    it('should be able to convert a testnet address to a cashaddr', function() {
+      var a = new Address('mysKEM9kN86Nkcqwb4gw7RqtDyc552LQoq');
+      a.toCashAddress().should.equal('bchtest:qry5cr6h2qe25pzwwfrz8m653fh2tf6nusj9dl0ujc');
+    });
 
     it('should fail convert no prefix addresses bad checksum ', function() {
       (function() {
@@ -221,6 +225,23 @@ describe('Address', function() {
     it('isValid returns true on network match on cashaddr testnet', function() {
       var valid = Address.isValid('bchtest:qrzm24wqva0gnvgcsyc0h8tdpgw462mgmc9lef83vw', 'testnet');
       valid.should.equal(true);
+    });
+
+    it('isValid returns true on regtest address', function() {
+      var valid = Address.isValid('qqww7zk6w7e6eu6299cwcu45ymwx7rmt3ckhj4xs0d', 'regtest');
+      valid.should.equal(true);
+    });
+
+    it('isValid returns true on regtest address when enableRegtest() is called on testnet', function() {
+      Networks.enableRegtest();
+      var valid = Address.isValid('qqww7zk6w7e6eu6299cwcu45ymwx7rmt3ckhj4xs0d', 'testnet');
+      valid.should.equal(true);
+    });
+
+    it('isValid returns false on regtest address when disableRegtest() is called on testnet', function() {
+      Networks.disableRegtest();
+      var valid = Address.isValid('qqww7zk6w7e6eu6299cwcu45ymwx7rmt3ckhj4xs0d', 'testnet');
+      valid.should.equal(false);
     });
 
     it('validates correctly the P2PKH test vector', function() {


### PR DESCRIPTION
There were a few bugs with isValid(12345, 'regtest')

* returned false for regtest addresses after enableRegtest() was called
 *  due to the testnet being selected as the network
 * then the comparison was checking the entire object instead of the prefix
 * since the network.name === 'testnet' the object compare returned false, since regtest was passed in. 


There were a few bugs with toCashAddress() on testnet addresses.
* concat on undefined due to testnet not having a prefixArray
* normally prefixArray is added when addNetwork is called but only if prefix is defined
* my previous refactor removed prefix for testnet and defined a dynamic property that toggles with enableRegtest()
* my prev refactor didn't define a dynamic property for prefixArray


Added tests for these scenarios
