### PR TITLE
No prefix via toCashAddress(false)

### DIFF
--- a/lib/address.js
+++ b/lib/address.js
@@ -635,7 +635,11 @@ Address.prototype.toCashBuffer = function() {
  */
 
 
-Address.prototype.toCashAddress = function() {
+Address.prototype.toCashAddress = function(withPrefix) {
+  if(withPrefix === undefined) {
+    withPrefix = true;
+  }
+  $.checkArgumentType(withPrefix, 'boolean', 'withPrefix');
   function getTypeBits(type) {
     switch (type) {
       case 'pubkeyhash':
@@ -677,7 +681,11 @@ Address.prototype.toCashAddress = function() {
   var payloadData = convertBits([versionByte].concat(arr), 8, 5);
   var checksumData = prefixData.concat(payloadData).concat(eight0);
   var payload = payloadData.concat(checksumToArray(polymod(checksumData)));
-  return this.network.prefix+ ':' + base32.encode(payload);
+  if(withPrefix) {
+    return this.network.prefix+ ':' + base32.encode(payload);
+  } else {
+    return base32.encode(payload);
+  }
 };
 
 

--- a/test/address.js
+++ b/test/address.js
@@ -126,6 +126,17 @@ describe('Address', function() {
       a.toCashAddress().should.equal('bchtest:qry5cr6h2qe25pzwwfrz8m653fh2tf6nusj9dl0ujc');
     });
 
+
+    it('should be able to convert a testnet address to a cashaddr without prefix', function() {
+      var a = new Address('mysKEM9kN86Nkcqwb4gw7RqtDyc552LQoq');
+      a.toCashAddress(false).should.equal('qry5cr6h2qe25pzwwfrz8m653fh2tf6nusj9dl0ujc');
+    });
+
+    it('should be able to convert a testnet address to a cashaddr with prefix', function() {
+      var a = new Address('mysKEM9kN86Nkcqwb4gw7RqtDyc552LQoq');
+      a.toCashAddress(true).should.equal('bchtest:qry5cr6h2qe25pzwwfrz8m653fh2tf6nusj9dl0ujc');
+    });
+
     it('should fail convert no prefix addresses bad checksum ', function() {
       (function() {
         var a = new Address('qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx7');


### PR DESCRIPTION
Supporting a common use-case, the cash address without the prefix on it.