### PR TITLE
Network magic property needs to be a buffer

### DIFF
--- a/lib/networks.js
+++ b/lib/networks.js
@@ -264,9 +264,9 @@ Object.defineProperty(testnet, 'networkMagic', {
   configurable: false,
   get: function() {
     if (this.regtestEnabled) {
-      return REGTEST.NETWORK_MAGIC;
+      return BufferUtil.integerAsBuffer(REGTEST.NETWORK_MAGIC);
     } else {
-      return TESTNET.NETWORK_MAGIC;
+      return BufferUtil.integerAsBuffer(TESTNET.NETWORK_MAGIC);
     }
   }
 });


### PR DESCRIPTION
In a previous refactor the conversion to a buffer was removed