### PR TITLE
Add possibility to select compression of WIF for Private Key

### DIFF
--- a/lib/privatekey.js
+++ b/lib/privatekey.js
@@ -300,25 +300,47 @@ PrivateKey.prototype.toString = function() {
 };
 
 /**
+ * Will output the PrivateKey to a WIF string leading to compressed Public Key form
+ *
+ * @returns {string} A WIP representation of the private key
+ */
+PrivateKey.prototype.toCompressedWIF = function() {
+  var network = this.network;
+  var compressed = this.compressed;
+
+  var buf = Buffer.concat([new Buffer([network.privatekey]),
+                          this.bn.toBuffer({size: 32}),
+                          new Buffer([0x01])]);
+
+  return Base58Check.encode(buf);
+};
+
+/**
+ * Will output the PrivateKey to a WIF string leading to uncompressed Public Key form
+ *
+ * @returns {string} A WIP representation of the private key
+ */
+PrivateKey.prototype.toUncompressedWIF = function() {
+  var network = this.network;
+  var compressed = this.compressed;
+
+  var buf = Buffer.concat([Buffer.from([network.privatekey]),
+                          this.bn.toBuffer({size: 32})]);
+
+  return Base58Check.encode(buf);
+};
+
+/**
  * Will output the PrivateKey to a WIF string
  *
  * @returns {string} A WIP representation of the private key
  */
 PrivateKey.prototype.toWIF = function() {
-  var network = this.network;
-  var compressed = this.compressed;
-
-  var buf;
-  if (compressed) {
-    buf = Buffer.concat([Buffer.from([network.privatekey]),
-                         this.bn.toBuffer({size: 32}),
-                         Buffer.from([0x01])]);
+  if (this.compressed) {
+    return this.toCompressedWIF();
   } else {
-    buf = Buffer.concat([Buffer.from([network.privatekey]),
-                         this.bn.toBuffer({size: 32})]);
+    return this.toUncompressedWIF();
   }
-
-  return Base58Check.encode(buf);
 };
 
 /**


### PR DESCRIPTION
I need to be able to produce both `compressed` and `uncompressed` private keys in WIF format

Here is some info why anyone need this functionality: https://github.com/OmniLayer/omniwallet/wiki/Converting-between-Compressed-and-Uncompressed-Addresses-and-Private-Keys