### PR TITLE
Don't encourage use of `new Buffer()` in examples

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -9,7 +9,7 @@ var address = privateKey.toAddress();
 
 ## Generate a address from a SHA256 hash
 ```javascript
-var value = new Buffer('correct horse battery staple');
+var value = Buffer.from('correct horse battery staple');
 var hash = bitcore.crypto.Hash.sha256(value);
 var bn = bitcore.crypto.BN.fromBuffer(hash);
 


### PR DESCRIPTION
We shouldn't encourage use of `new Buffer()`. It's been deprecated for two years and if not used carefully can result in pretty major security vulnerabilities.