### PR TITLE
Don't mutate the elliptic curve prototype with get* additions

### DIFF
--- a/bitcore-lib.js
+++ b/bitcore-lib.js
@@ -2084,7 +2084,7 @@ Point.getN = function getN() {
   return new BN(ec.curve.n.toArray());
 };
 
-Point.prototype._getX = Point.prototype.getX;
+Point._getX = Point.prototype.getX;
 
 /**
  *
@@ -2092,11 +2092,11 @@ Point.prototype._getX = Point.prototype.getX;
  *
  * @returns {BN} A BN instance of the X coordinate
  */
-Point.prototype.getX = function getX() {
+Point.getX = function getX() {
   return new BN(this._getX().toArray());
 };
 
-Point.prototype._getY = Point.prototype.getY;
+Point._getY = Point.prototype.getY;
 
 /**
  *
@@ -2104,7 +2104,7 @@ Point.prototype._getY = Point.prototype.getY;
  *
  * @returns {BN} A BN instance of the Y coordinate
  */
-Point.prototype.getY = function getY() {
+Point.getY = function getY() {
   return new BN(this._getY().toArray());
 };
 

--- a/lib/crypto/point.js
+++ b/lib/crypto/point.js
@@ -73,7 +73,7 @@ Point.getN = function getN() {
   return new BN(ec.curve.n.toArray());
 };
 
-Point.prototype._getX = Point.prototype.getX;
+Point._getX = Point.prototype.getX;
 
 /**
  *
@@ -81,11 +81,11 @@ Point.prototype._getX = Point.prototype.getX;
  *
  * @returns {BN} A BN instance of the X coordinate
  */
-Point.prototype.getX = function getX() {
+Point.getX = function getX() {
   return new BN(this._getX().toArray());
 };
 
-Point.prototype._getY = Point.prototype.getY;
+Point._getY = Point.prototype.getY;
 
 /**
  *
@@ -93,7 +93,7 @@ Point.prototype._getY = Point.prototype.getY;
  *
  * @returns {BN} A BN instance of the Y coordinate
  */
-Point.prototype.getY = function getY() {
+Point.getY = function getY() {
   return new BN(this._getY().toArray());
 };
 


### PR DESCRIPTION
Point's prototype is set to the prototype of `ec('secp256k1').curve.point()`, which means the library itself is global state, and mutation to it is shared across users of 'elliptic'.

This is not generally a problem, for example, with `validate` it's a simple set, so the greatest risk is that it will be directly overwritten.

But in the case of `getX` and `getY`, both methods are overwritten with others that depend on the prior implementation as stored in `_get*`. If this happens twice, then the implementation of `_getX` is replaced with something that depends on a call to `_getX`, and the callers is stuck in an infinite loop.

Here's an example of the infinite loop, which I came across by interaction between bitcore-lib-dash and zcash-bitcore-lib, but by inspection it seems they are both downstream of this code.

```
at Point.getX [as _getX] (/bitcore-lib/lib/crypto/point.js:75:22)
    at Point.getX [as _getX] (/bitcore-lib/lib/crypto/point.js:75:22)
    at Point.getX [as _getX] (/bitcore-lib/lib/crypto/point.js:75:22)
    at Point.getX [as _getX] (/bitcore-lib/lib/crypto/point.js:75:22)
    at Point.getX (/zcash-bitcore-lib/lib/crypto/point.js:75:22)
    at Point.validate (/zcash-bitcore-lib/lib/crypto/point.js:105:12)
    at Function.fromX (/bitcore-lib/lib/crypto/point.js:40:9)
    at Function.PublicKey._transformX (/bitcore-lib/lib/publickey.js:192:22)
    at Function.PublicKey._transformDER (/bitcore-lib/lib/publickey.js:168:22)
    at PublicKey._classifyArgs (/bitcore-lib/lib/publickey.js:83:22)
    at new PublicKey (/bitcore-lib/lib/publickey.js:50:19)
    at HDPublicKey._buildFromBuffers (/bitcore-lib/lib/hdpublickey.js:321:19)
    at HDPublicKey._buildFromSerialized (/bitcore-lib/lib/hdpublickey.js:273:15)
    at new HDPublicKey (/bitcore-lib/lib/hdpublickey.js:45:21)
````