### PR TITLE
Fix lib/crypto/point.js lints

### DIFF
--- a/lib/crypto/point.js
+++ b/lib/crypto/point.js
@@ -21,8 +21,9 @@ var ecPointFromX = ec.curve.pointFromX.bind(ec.curve);
  * @constructor
  */
 var Point = function Point(x, y, isRed) {
+  var point = null;
   try {
-    var point = ecPoint(x, y, isRed);
+    point = ecPoint(x, y, isRed);
   } catch (e) {
     throw new Error('Invalid Point');
   }
@@ -42,8 +43,9 @@ Point.prototype = Object.getPrototypeOf(ec.curve.point());
  * @returns {Point} An instance of Point
  */
 Point.fromX = function fromX(odd, x){
+  var point = null;
   try {
-    var point = ecPointFromX(x, odd);
+    point = ecPointFromX(x, odd);
   } catch (e) {
     throw new Error('Invalid X');
   }


### PR DESCRIPTION
In the spirit of "leave a thing better than you found it":

lib/crypto/point.js: line 29, col 3, 'point' used out of scope.
lib/crypto/point.js: line 30, col 10, 'point' used out of scope.
lib/crypto/point.js: line 50, col 3, 'point' used out of scope.
lib/crypto/point.js: line 51, col 10, 'point' used out of scope.