### PR TITLE
Fix grammar in examples.md

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -7,7 +7,7 @@ var privateKey = new bitcore.PrivateKey();
 var address = privateKey.toAddress();
 ```
 
-## Generate a address from a SHA256 hash
+## Generate an address from a SHA256 hash
 ```javascript
 var value = Buffer.from('correct horse battery staple');
 var hash = bitcore.crypto.Hash.sha256(value);


### PR DESCRIPTION
Just fixes up the grammar in `examples.md`

 Generate **a** address from a SHA256 hash

to

Generate **an** address from a SHA256 hash