### PR TITLE
Add "Don't sort option" to Multisig inputs - Can't redeem unsorted multisig pubkeys

### DIFF
--- a/lib/transaction/input/multisig.js
+++ b/lib/transaction/input/multisig.js
@@ -17,13 +17,18 @@ var TransactionSignature = require('../signature');
 /**
  * @constructor
  */
-function MultiSigInput(input, pubkeys, threshold, signatures) {
+function MultiSigInput(input, pubkeys, threshold, signatures, opts) {
+  opts = opts || {};
   Input.apply(this, arguments);
   var self = this;
   pubkeys = pubkeys || input.publicKeys;
   threshold = threshold || input.threshold;
   signatures = signatures || input.signatures;
-  this.publicKeys = _.sortBy(pubkeys, function(publicKey) { return publicKey.toString('hex'); });
+  if (opts.noSorting) {
+    this.publicKeys = pubkeys
+  } else  {
+    this.publicKeys = _.sortBy(pubkeys, function(publicKey) { return publicKey.toString('hex'); });
+  }
   $.checkState(Script.buildMultisigOut(this.publicKeys, threshold).equals(this.output.script),
     'Provided public keys don\'t match to the provided output script');
   this.publicKeyIndex = {};

--- a/lib/transaction/input/multisigscripthash.js
+++ b/lib/transaction/input/multisigscripthash.js
@@ -19,15 +19,20 @@ var TransactionSignature = require('../signature');
 /**
  * @constructor
  */
-function MultiSigScriptHashInput(input, pubkeys, threshold, signatures, nestedWitness) {
+function MultiSigScriptHashInput(input, pubkeys, threshold, signatures, nestedWitness, opts) {
   /* jshint maxstatements:20 */
+  opts = opts || {};
   Input.apply(this, arguments);
   var self = this;
   pubkeys = pubkeys || input.publicKeys;
   threshold = threshold || input.threshold;
   signatures = signatures || input.signatures;
   this.nestedWitness = nestedWitness ? true : false;
-  this.publicKeys = _.sortBy(pubkeys, function(publicKey) { return publicKey.toString('hex'); });
+  if (opts.noSorting) {
+    this.publicKeys = pubkeys
+  } else  {
+    this.publicKeys = _.sortBy(pubkeys, function(publicKey) { return publicKey.toString('hex'); });
+  }
   this.redeemScript = Script.buildMultisigOut(this.publicKeys, threshold);
   if (this.nestedWitness) {
     var nested = Script.buildWitnessMultisigOutFromScript(this.redeemScript);

--- a/lib/transaction/transaction.js
+++ b/lib/transaction/transaction.js
@@ -606,8 +606,11 @@ Transaction.prototype._newTransaction = function() {
  * @param {Array=} pubkeys
  * @param {number=} threshold
  * @param {boolean=} nestedWitness - Indicates that the utxo is nested witness p2sh
+ * @param {Object=} opts - Several options:
+ *        - noSorting: defaults to false, if true and is multisig, don't
+ *                      sort the given public keys before creating the script
  */
-Transaction.prototype.from = function(utxo, pubkeys, threshold, nestedWitness) {
+Transaction.prototype.from = function(utxo, pubkeys, threshold, nestedWitness, opts) {
   if (_.isArray(utxo)) {
     var self = this;
     _.each(utxo, function(utxo) {
@@ -623,7 +626,7 @@ Transaction.prototype.from = function(utxo, pubkeys, threshold, nestedWitness) {
     return this;
   }
   if (pubkeys && threshold) {
-    this._fromMultisigUtxo(utxo, pubkeys, threshold, nestedWitness);
+    this._fromMultisigUtxo(utxo, pubkeys, threshold, nestedWitness, opts);
   } else {
     this._fromNonP2SH(utxo);
   }
@@ -651,7 +654,7 @@ Transaction.prototype._fromNonP2SH = function(utxo) {
   }));
 };
 
-Transaction.prototype._fromMultisigUtxo = function(utxo, pubkeys, threshold, nestedWitness) {
+Transaction.prototype._fromMultisigUtxo = function(utxo, pubkeys, threshold, nestedWitness, opts) {
   $.checkArgument(threshold <= pubkeys.length,
     'Number of required signatures must be greater than the number of public keys');
   var clazz;
@@ -671,7 +674,7 @@ Transaction.prototype._fromMultisigUtxo = function(utxo, pubkeys, threshold, nes
     prevTxId: utxo.txId,
     outputIndex: utxo.outputIndex,
     script: Script.empty()
-  }, pubkeys, threshold, false, nestedWitness));
+  }, pubkeys, threshold, false, nestedWitness, opts));
 };
 
 /**


### PR DESCRIPTION
During the creation of multisig outputs, it gives the option not to sort the public keys. However, it is not allowed to redeem unsorted public keys without interacting with the low level `addInput` function.

- Does not change the default behavior.
- Please push this to bitcore-lib-cash too.

@matiu 